### PR TITLE
chore: rename vigilant-dollop to oidc-cli

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,19 +45,19 @@ changelog:
 brews:
   - name: oidc-cli
     description: Command-line OIDC client, get a token without all the fuss
-    homepage: https://github.com/jentz/vigilant-dollop
+    homepage: https://github.com/jentz/oidc-cli
     license: MIT
     directory: Formula
     repository:
       owner: jentz
-      name: homebrew-vigilant-dollop
+      name: homebrew-oidc-cli
 
 scoops:
   - name: oidc-cli
     description: Command-line OIDC client, get a token without all the fuss
     directory: bucket
-    homepage: https://github.com/jentz/vigilant-dollop
+    homepage: https://github.com/jentz/oidc-cli
     license: MIT
     repository:
       owner: jentz
-      name: scoop-vigilant-dollop
+      name: scoop-oidc-cli

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vigilant-dollop
+# oidc-cli
 Command-line OIDC client, get a token without all the fuss
 
 ## Usage
@@ -25,11 +25,11 @@ Run `oidc-cli <command> -h` to get help for a specific command
 
 Installing with homebrew
 ```bash
- brew tap jentz/vigilant-dollop
+ brew tap jentz/oidc-cli
  brew install oidc-cli
  ```
 
-You can also download a suitable release for your platform from the [releases page](https://github.com/jentz/vigilant-dollop/releases).
+You can also download a suitable release for your platform from the [releases page](https://github.com/jentz/oidc-cli/releases).
 
 ## Run
 

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -3,8 +3,8 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/crypto"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/crypto"
+	"github.com/jentz/oidc-cli/pkg/log"
 )
 
 type AuthorizationCodeFlow struct {

--- a/authorization_request.go
+++ b/authorization_request.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/gorilla/schema"
-	"github.com/jentz/vigilant-dollop/pkg/log"
-	"github.com/jentz/vigilant-dollop/pkg/webflow"
+	"github.com/jentz/oidc-cli/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/webflow"
 )
 
 type AuthorizationRequest struct {

--- a/client.go
+++ b/client.go
@@ -1,7 +1,7 @@
 package oidc
 
 import (
-	"github.com/jentz/vigilant-dollop/pkg/transport"
+	"github.com/jentz/oidc-cli/pkg/transport"
 	"net/http"
 	"time"
 )

--- a/client_credentials.go
+++ b/client_credentials.go
@@ -3,7 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 )
 
 type ClientCredentialsFlow struct {

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func TestParseAuthorizationCodeFlagsResult(t *testing.T) {

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func TestParseClientCredentialsFlagsResult(t *testing.T) {

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -3,9 +3,9 @@ package main
 import (
 	"bytes"
 	"flag"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, remainingArgs []string, output string, err error) {

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func TestParseGlobalFlagsResult(t *testing.T) {

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"os"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func TestParseIntrospectFlagsResult(t *testing.T) {

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -9,8 +9,8 @@ import (
 	"slices"
 	"syscall"
 
-	oidc "github.com/jentz/vigilant-dollop"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	oidc "github.com/jentz/oidc-cli"
+	"github.com/jentz/oidc-cli/pkg/log"
 )
 
 type CommandRunner interface {

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"os"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	oidc "github.com/jentz/vigilant-dollop"
+	oidc "github.com/jentz/oidc-cli"
 )
 
 func TestParseTokenRefreshFlagsResult(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jentz/vigilant-dollop
+module github.com/jentz/oidc-cli
 
 go 1.23.9
 

--- a/introspect.go
+++ b/introspect.go
@@ -3,7 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 )
 
 type IntrospectFlow struct {

--- a/introspection_request.go
+++ b/introspection_request.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 	"io"
 	"net/http"
 	"net/url"

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -3,7 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/crypto"
+	"github.com/jentz/oidc-cli/pkg/crypto"
 )
 
 type AuthMethodValue string

--- a/par_request.go
+++ b/par_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 	"net/http"
 	"net/url"
 	"strings"

--- a/pkg/webflow/callback.go
+++ b/pkg/webflow/callback.go
@@ -5,7 +5,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 	"net"
 	"net/http"
 	"net/url"

--- a/pkg/webflow/callback_test.go
+++ b/pkg/webflow/callback_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 	"net"
 	"net/http"
 	"net/http/httptest"

--- a/token_refresh.go
+++ b/token_refresh.go
@@ -3,7 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 )
 
 type TokenRefreshFlow struct {

--- a/token_request.go
+++ b/token_request.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/jentz/vigilant-dollop/pkg/log"
+	"github.com/jentz/oidc-cli/pkg/log"
 	"net/http"
 	"net/url"
 	"strings"


### PR DESCRIPTION
This pull request updates the project name and repository references from "vigilant-dollop" to "oidc-cli" across multiple files. It includes changes to documentation, configuration files, and import paths in the codebase to ensure consistency with the new project name.

### Documentation Updates:
* Updated the project name in `README.md` from "vigilant-dollop" to "oidc-cli" and replaced references to the old repository URL with the new one. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R32)

### Configuration Updates:
* Updated `.goreleaser.yaml` to reflect the new repository name and homepage for Homebrew and Scoop package configurations.

### Codebase Updates:
* Changed all import paths in Go files to use `github.com/jentz/oidc-cli` instead of `github.com/jentz/vigilant-dollop`. This includes updates in files such as `authorization_code.go`, `authorization_request.go`, `client.go`, `client_credentials.go`, and various files under the `cmd` directory. [[1]](diffhunk://#diff-ed14677a2ec6e4c99bcfaf3499532410a415fde8930550ca61c47ee22010f940L6-R7) [[2]](diffhunk://#diff-09ffd35a35d1eeba724e5aa9fd69d5bff3146196dce8ef43858450387f55419dL13-R14) [[3]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL4-R4) [[4]](diffhunk://#diff-53aa1493fd95ff186b11707cbe431153add74d598281829327d5360a9b2852b0L6-R6) [[5]](diffhunk://#diff-61b8fcf5394df2615d47fefcd1de55840b62c10ae1fa35aab8bfff52ed71bf85L7-R7) [[6]](diffhunk://#diff-07692782abca96fe52f2db16174fb9dbff0ec3c05d4f9c8508874522ef0d3144L7-R7) [[7]](diffhunk://#diff-b56595ac9258b94ff99b99a045ca01777998be4f53d95c8188e2ff6940aa7fbcL7-R7) [[8]](diffhunk://#diff-a7e866b2d06b8eba792b55d202ea3f047553a3348b17d8cb9d0020e53d90d96eL7-R7) [[9]](diffhunk://#diff-595c7d4d1fe14764a6a87119dcb29496cd7e084d7f2a972787052804c02764acL6-R8) [[10]](diffhunk://#diff-900e993421b5745c0d255c115d51281b10c43307848bedca8bafa730074ae853L7-R7) [[11]](diffhunk://#diff-c401859b3bfc152cb76835bb85889483bb5d979a40985402322d1a91960f1f81L9-R9) [[12]](diffhunk://#diff-649d7b1a8f8d74e679f70de60efbecbaa8aea36cd33571cc5b59f7664de1a8afL7-R7) [[13]](diffhunk://#diff-07130e93207a707d37904a8068f39ad1cf2974f2b2bfb81955f643c93f25e831L12-R13) [[14]](diffhunk://#diff-a310174e4d0a206b748fe8e4d3153ca7ecd93a44e40de51db04ac7a95a0eb97cL9-R9) [[15]](diffhunk://#diff-ec35305cedcd5755b5d39c94b1df6174d0395237299ff8013a7023464b8bd6e0L7-R7)
* Updated the `go.mod` file to reflect the new module path `github.com/jentz/oidc-cli`.