### PR TITLE
feat: add Makefile for build and test automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Makefile for oidc-cli
+
+.PHONY: help test build lint clean coverage
+
+BINARY=oidc-cli
+
+help:
+	@echo "\nUsage: make <target>\n"
+	@echo "Targets:"
+	@echo "  help     Show this help message"
+	@echo "  test     Run all Go tests (go test -v ./...)"
+	@echo "  build    Build the oidc-cli binary (go build -v -o $(BINARY))"
+	@echo "  lint     Run golangci-lint (uses .golangci.yaml config)"
+	@echo "  clean    Remove built binaries and test cache"
+	@echo "  coverage  Run tests with coverage and generate coverage.out"
+
+# Run all tests
+
+test:
+	go test ./...
+
+# Build the binary
+
+build:
+	go build -v -o $(BINARY)
+
+# Lint the codebase
+
+lint:
+	golangci-lint run
+
+# Clean up build artifacts and test cache
+
+clean:
+	rm -f $(BINARY)
+	go clean -testcache
+
+# Run tests with coverage
+
+coverage:
+	go test -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
This pull request introduces a `Makefile` to streamline common development tasks for the `oidc-cli` project. The `Makefile` provides targets for building, testing, linting, cleaning, and generating test coverage reports.

Key additions:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R41): Added targets to automate tasks including `help`, `test`, `build`, `lint`, `clean`, and `coverage`. Each target is designed to simplify developer workflows, such as running tests (`test`), building the binary (`build`), and cleaning up artifacts (`clean`).