### PR TITLE
feat: update goreleaser configuration for Homebrew casks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,15 +42,21 @@ changelog:
       - "^docs:"
       - "^test:"
 
-brews:
+homebrew_casks:
   - name: oidc-cli
     description: Command-line OIDC client, get a token without all the fuss
     homepage: https://github.com/jentz/oidc-cli
     license: MIT
-    directory: Formula
+    directory: Casks
     repository:
       owner: jentz
       name: homebrew-oidc-cli
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/oidc-cli"]
+          end
 
 scoops:
   - name: oidc-cli


### PR DESCRIPTION
Migrates away from the deprecated `brew` Formula configuration and uses `homebrew_casks` instead.
