### PR TITLE
chore: improve homebrew migration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,6 +51,8 @@ homebrew_casks:
     repository:
       owner: jentz
       name: homebrew-oidc-cli
+    conflicts:
+      - formula: oidc-cli
     hooks:
       post:
         install: |


### PR DESCRIPTION
Cause the cask to conflict with the deprecated formula to help the user understand there should only be the cask.