### PR TITLE
feat: add GitHub Copilot initialization instructions 

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# .github/copilot-instructions.md
+
+# GitHub Copilot Initialization for oidc-cli
+
+This file provides guidance to GitHub Copilot when working with code in this repository.
+
+## Project Overview
+- **Language:** Go
+- **Type:** CLI application implementing an OIDC (OpenID Connect) client
+- **Key Features:**
+  - Supports Authorization Code, Client Credentials, Token Refresh, and Token Introspection flows
+  - Modular architecture with clear package separation
+  - Command pattern for CLI commands
+
+## Directory Structure
+- `main.go`: Entry point
+- `cmd/`: CLI command parsing, flag handling, and command execution
+- `oidc/`: OIDC client logic and flow implementations
+- `httpclient/`: HTTP client wrapper for OAuth2/OIDC
+- `crypto/`: Cryptographic utilities (PKCE, DPoP, PEM)
+- `webflow/`: Browser-based authorization flow and callback server
+- `log/`: Logging utilities
+
+## Development Best Practices
+- Use idiomatic Go and follow effective Go guidelines
+- Write small, testable functions
+- Use context for cancellation and timeouts in networked code
+- Handle errors explicitly and propagate them up
+- Keep CLI flags and configuration logic in `cmd/`
+
+## Testing
+- Use Go's standard testing framework
+- Run all tests with `go test ./...`
+- Use table-driven tests for coverage and clarity
+- Mock external dependencies where possible
+
+## Build & Lint
+- Build: `make build` or `go build -v -o oidc-cli`
+- Lint: `make lint` (uses golangci-lint)
+- Clean: `make clean`
+
+## Copilot Usage Tips
+- Suggest Go code that follows the above structure and practices
+- When generating new commands, implement the `CommandRunner` interface
+- For new OIDC flows, add logic in `oidc/` and wire up in `cmd/`
+- For cryptographic features, use the `crypto/` package
+- For browser-based flows, use the `webflow/` package
+- Add and update tests for all new features
+
+---
+This file is intended to help Copilot generate code that is idiomatic, maintainable, and consistent with the architecture and practices of this repository.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24
-
+          go-version-file: "go.mod"
+  
       - name: Cache Go modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [ "**"]
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: lint
@@ -13,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: "go.mod"
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: "go.mod"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
This pull request introduces a new Copilot guidance file for the repository and updates the GitHub Actions workflows to dynamically determine the Go version from the `go.mod` file. Additionally, it includes a minor permissions update in the lint workflow. Below is a summary of the most important changes:

### Copilot Guidance
* Added `.github/COPILOT.md` to provide detailed instructions for GitHub Copilot, including project structure, development best practices, testing guidelines, and usage tips for generating code consistent with the repository's architecture.

### Workflow Improvements
* Updated `build.yml`, `lint.yml`, and `release.yml` workflows to use `go-version-file: "go.mod"` instead of hardcoding the Go version, ensuring consistency with the project's dependencies. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L26-R26) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L16-R19) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R24)
* Added `contents: read` permissions to the `lint.yml` workflow under the `on:` section, improving security and access control.