### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/jentz/oidc-cli/log"

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"text/template"
 	"time"
 
 	"github.com/jentz/oidc-cli/log"


### PR DESCRIPTION
Potential fix for [https://github.com/jentz/oidc-cli/security/code-scanning/2](https://github.com/jentz/oidc-cli/security/code-scanning/2)

To fix this vulnerability, user-controlled data must be properly escaped before being rendered in the HTTP response. The best way to do this in Go is to use the `html/template` package instead of `text/template` for rendering HTML responses. The `html/template` package automatically escapes data when rendering, preventing XSS. 

**Steps to fix:**
- Change the import from `text/template` to `html/template` in `webflow/callback.go`.
- Ensure that all templates (`s.errorTmpl`, `s.successTmpl`) are created using `html/template.New(...)` or `template.ParseFS(...)` from `html/template`.
- Update any code that uses `text/template` to use `html/template` instead.

**Required changes:**
- Update the import statement.
- Update any references to `text/template` to `html/template`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
