### PR TITLE
feat: add auth code testability

### DIFF
--- a/httpclient/auth_flow_components.go
+++ b/httpclient/auth_flow_components.go
@@ -1,0 +1,51 @@
+package httpclient
+
+import (
+	"context"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+// CallbackServerManager handles the lifecycle of callback servers for OAuth flows.
+type CallbackServerManager interface {
+	// StartServer creates and starts a callback server, returning it for later use.
+	StartServer(ctx context.Context, callback string) (*webflow.CallbackServer, error)
+	// WaitForCallback waits for the OAuth callback response from the server.
+	WaitForCallback(ctx context.Context, server *webflow.CallbackServer) (*webflow.CallbackResponse, error)
+}
+
+// AuthorizationURLBuilder constructs OAuth authorization URLs.
+type AuthorizationURLBuilder interface {
+	// BuildAuthorizationURL creates a complete authorization URL from the endpoint and request parameters.
+	BuildAuthorizationURL(endpoint string, req *AuthorizationCodeRequest) (string, error)
+}
+
+// BrowserLauncher opens URLs in the user's default browser.
+type BrowserLauncher interface {
+	// OpenURL opens the specified URL in the system's default browser.
+	OpenURL(url string) error
+}
+
+// ResponseValidator validates and transforms OAuth callback responses.
+type ResponseValidator interface {
+	// ValidateResponse validates the callback response and returns the authorization code response.
+	ValidateResponse(req *AuthorizationCodeRequest, resp *webflow.CallbackResponse) (*AuthorizationCodeResponse, error)
+}
+
+// AuthFlowDependencies holds all the dependencies needed for authorization code flow.
+type AuthFlowDependencies struct {
+	ServerManager     CallbackServerManager
+	URLBuilder        AuthorizationURLBuilder
+	BrowserLauncher   BrowserLauncher
+	ResponseValidator ResponseValidator
+}
+
+// NewAuthFlowDependencies creates a new set of dependencies with default implementations.
+func NewAuthFlowDependencies() *AuthFlowDependencies {
+	return &AuthFlowDependencies{
+		ServerManager:     &DefaultCallbackServerManager{},
+		URLBuilder:        &DefaultAuthorizationURLBuilder{},
+		BrowserLauncher:   NewDefaultBrowserLauncher(),
+		ResponseValidator: &DefaultResponseValidator{},
+	}
+}

--- a/httpclient/authorization_code_integration_test.go
+++ b/httpclient/authorization_code_integration_test.go
@@ -1,0 +1,201 @@
+package httpclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+// MockAuthFlowDependencies creates a set of mock dependencies for testing.
+type MockAuthFlowDependencies struct {
+	ServerManager     CallbackServerManager
+	URLBuilder        AuthorizationURLBuilder
+	BrowserLauncher   BrowserLauncher
+	ResponseValidator ResponseValidator
+}
+
+// MockCallbackServerManager for testing.
+type MockCallbackServerManager struct {
+	StartServerFunc     func(ctx context.Context, callback string) (*webflow.CallbackServer, error)
+	WaitForCallbackFunc func(ctx context.Context, server *webflow.CallbackServer) (*webflow.CallbackResponse, error)
+}
+
+func (m *MockCallbackServerManager) StartServer(ctx context.Context, callback string) (*webflow.CallbackServer, error) {
+	if m.StartServerFunc != nil {
+		return m.StartServerFunc(ctx, callback)
+	}
+	return nil, nil
+}
+
+func (m *MockCallbackServerManager) WaitForCallback(ctx context.Context, server *webflow.CallbackServer) (*webflow.CallbackResponse, error) {
+	if m.WaitForCallbackFunc != nil {
+		return m.WaitForCallbackFunc(ctx, server)
+	}
+	return nil, nil
+}
+
+// MockAuthorizationURLBuilder for testing.
+type MockAuthorizationURLBuilder struct {
+	BuildAuthorizationURLFunc func(endpoint string, req *AuthorizationCodeRequest) (string, error)
+}
+
+func (m *MockAuthorizationURLBuilder) BuildAuthorizationURL(endpoint string, req *AuthorizationCodeRequest) (string, error) {
+	if m.BuildAuthorizationURLFunc != nil {
+		return m.BuildAuthorizationURLFunc(endpoint, req)
+	}
+	return "", nil
+}
+
+// MockBrowserLauncher (reusing from browser_launcher_test.go concept)
+type MockBrowserLauncherForIntegration struct {
+	OpenURLFunc func(url string) error
+}
+
+func (m *MockBrowserLauncherForIntegration) OpenURL(url string) error {
+	if m.OpenURLFunc != nil {
+		return m.OpenURLFunc(url)
+	}
+	return nil
+}
+
+// MockResponseValidator for testing.
+type MockResponseValidator struct {
+	ValidateResponseFunc func(req *AuthorizationCodeRequest, resp *webflow.CallbackResponse) (*AuthorizationCodeResponse, error)
+}
+
+func (m *MockResponseValidator) ValidateResponse(req *AuthorizationCodeRequest, resp *webflow.CallbackResponse) (*AuthorizationCodeResponse, error) {
+	if m.ValidateResponseFunc != nil {
+		return m.ValidateResponseFunc(req, resp)
+	}
+	return nil, nil
+}
+
+// TestExecuteAuthorizationCodeRequest_WithMocks covers the scenario of executing an authorization code request with mocked dependencies.
+func TestExecuteAuthorizationCodeRequest_WithMocks(t *testing.T) {
+	client := NewClient(nil)
+
+	// Create mock dependencies
+	mockDeps := &AuthFlowDependencies{
+		ServerManager: &MockCallbackServerManager{
+			StartServerFunc: func(_ context.Context, callback string) (*webflow.CallbackServer, error) {
+				// Mock server creation - we can verify the callback URL
+				if callback != "http://localhost:8080/callback" {
+					t.Errorf("Expected callback http://localhost:8080/callback, got %s", callback)
+				}
+				return &webflow.CallbackServer{}, nil // Return a mock server
+			},
+			WaitForCallbackFunc: func(_ context.Context, _ *webflow.CallbackServer) (*webflow.CallbackResponse, error) {
+				// Mock successful callback response
+				return &webflow.CallbackResponse{
+					Code:  "test-auth-code",
+					State: "test-state",
+				}, nil
+			},
+		},
+		URLBuilder: &MockAuthorizationURLBuilder{
+			BuildAuthorizationURLFunc: func(endpoint string, req *AuthorizationCodeRequest) (string, error) {
+				// Mock URL building - we can verify the parameters
+				if endpoint != "https://auth.example.com/authorize" {
+					t.Errorf("Expected endpoint https://auth.example.com/authorize, got %s", endpoint)
+				}
+				if req.ClientID != "test-client" {
+					t.Errorf("Expected client ID test-client, got %s", req.ClientID)
+				}
+				return "https://auth.example.com/authorize?client_id=test-client&response_type=code&state=test-state", nil
+			},
+		},
+		BrowserLauncher: &MockBrowserLauncherForIntegration{
+			OpenURLFunc: func(url string) error {
+				// Mock browser opening - we can verify the URL
+				expectedURL := "https://auth.example.com/authorize?client_id=test-client&response_type=code&state=test-state"
+				if url != expectedURL {
+					t.Errorf("Expected URL %s, got %s", expectedURL, url)
+				}
+				return nil
+			},
+		},
+		ResponseValidator: &MockResponseValidator{
+			ValidateResponseFunc: func(req *AuthorizationCodeRequest, resp *webflow.CallbackResponse) (*AuthorizationCodeResponse, error) {
+				// Mock response validation - we can verify the validation logic
+				if req.State != resp.State {
+					t.Errorf("State mismatch: expected %s, got %s", req.State, resp.State)
+				}
+				return &AuthorizationCodeResponse{
+					Code:  resp.Code,
+					State: resp.State,
+				}, nil
+			},
+		},
+	}
+
+	// Inject the mock dependencies
+	client.SetAuthFlowDependencies(mockDeps)
+
+	// Execute the authorization code request
+	ctx := context.Background()
+	req := &AuthorizationCodeRequest{
+		ClientID: "test-client",
+		State:    "test-state",
+	}
+
+	resp, err := client.ExecuteAuthorizationCodeRequest(ctx, "https://auth.example.com/authorize", "http://localhost:8080/callback", req)
+
+	// Verify the results
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Response should not be nil")
+	}
+
+	if resp.Code != "test-auth-code" {
+		t.Errorf("Expected code test-auth-code, got %s", resp.Code)
+	}
+
+	if resp.State != "test-state" {
+		t.Errorf("Expected state test-state, got %s", resp.State)
+	}
+}
+
+// TestExecuteAuthorizationCodeRequest_ComponentIsolation demonstrates how individual
+// components can be tested in isolation.
+func TestExecuteAuthorizationCodeRequest_ComponentIsolation(t *testing.T) {
+	client := NewClient(nil)
+
+	// Test scenario: Server manager fails to start server
+	mockDeps := &AuthFlowDependencies{
+		ServerManager: &MockCallbackServerManager{
+			StartServerFunc: func(_ context.Context, _ string) (*webflow.CallbackServer, error) {
+				return nil, &Error{
+					ErrorType:        "server_error",
+					ErrorDescription: "Failed to start callback server",
+					StatusCode:       500,
+				}
+			},
+		},
+		URLBuilder:        &DefaultAuthorizationURLBuilder{}, // Use real implementation
+		BrowserLauncher:   NewDefaultBrowserLauncher(),       // Use real implementation
+		ResponseValidator: &DefaultResponseValidator{},       // Use real implementation
+	}
+
+	client.SetAuthFlowDependencies(mockDeps)
+
+	ctx := context.Background()
+	req := &AuthorizationCodeRequest{
+		ClientID: "test-client",
+		State:    "test-state",
+	}
+
+	_, err := client.ExecuteAuthorizationCodeRequest(ctx, "https://auth.example.com/authorize", "http://localhost:8080/callback", req)
+
+	// Verify that the server error is properly propagated
+	if err == nil {
+		t.Error("Expected error from server manager, got nil")
+	}
+
+	if err.Error() != "error: server_error - Failed to start callback server, status: 500" {
+		t.Errorf("Expected server error, got: %v", err)
+	}
+}

--- a/httpclient/authorization_code_test.go
+++ b/httpclient/authorization_code_test.go
@@ -236,8 +236,6 @@ func TestCreateAuthorizationCodeRequestURL(t *testing.T) {
 	}
 }
 
-// TODO: ExecuteAuthorizationCodeRequest needs to be broken down
-// and made more testable with mocks to get further
 func TestExecuteAuthorizationCodeRequest_BasicValidation(t *testing.T) {
 	// Test basic parameter validation without actually executing the flow
 	client := NewClient(nil)
@@ -360,7 +358,7 @@ func TestStateValidationLogic(t *testing.T) {
 					}
 					return ""
 				}()
-				
+
 				response := &AuthorizationCodeResponse{
 					Code:  callbackResp.Code,
 					State: expectedState,

--- a/httpclient/browser_launcher.go
+++ b/httpclient/browser_launcher.go
@@ -1,0 +1,33 @@
+package httpclient
+
+import (
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+// DefaultBrowserLauncher implements BrowserLauncher using the webflow.Browser.
+type DefaultBrowserLauncher struct {
+	browser webflow.Browser
+}
+
+// Ensure DefaultBrowserLauncher implements the interface.
+var _ BrowserLauncher = (*DefaultBrowserLauncher)(nil)
+
+// NewDefaultBrowserLauncher creates a new DefaultBrowserLauncher with the default browser.
+func NewDefaultBrowserLauncher() *DefaultBrowserLauncher {
+	return &DefaultBrowserLauncher{
+		browser: webflow.NewBrowser(),
+	}
+}
+
+// NewDefaultBrowserLauncherWithBrowser creates a new DefaultBrowserLauncher with a custom browser.
+// This is useful for testing with mock browsers.
+func NewDefaultBrowserLauncherWithBrowser(browser webflow.Browser) *DefaultBrowserLauncher {
+	return &DefaultBrowserLauncher{
+		browser: browser,
+	}
+}
+
+// OpenURL opens the specified URL in the system's default browser.
+func (b *DefaultBrowserLauncher) OpenURL(url string) error {
+	return b.browser.Open(url)
+}

--- a/httpclient/browser_launcher_test.go
+++ b/httpclient/browser_launcher_test.go
@@ -1,0 +1,112 @@
+package httpclient
+
+import (
+	"errors"
+	"testing"
+)
+
+// MockBrowser is a mock implementation of webflow.Browser for testing.
+type MockBrowser struct {
+	openFunc func(url string) error
+}
+
+func (m *MockBrowser) Open(url string) error {
+	if m.openFunc != nil {
+		return m.openFunc(url)
+	}
+	return nil
+}
+
+func TestDefaultBrowserLauncher_OpenURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		mockOpen   func(url string) error
+		wantErr    bool
+		errMessage string
+	}{
+		{
+			name: "successful open",
+			url:  "https://example.com",
+			mockOpen: func(url string) error {
+				if url != "https://example.com" {
+					t.Errorf("Expected URL https://example.com, got %s", url)
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "browser error",
+			url:  "https://example.com",
+			mockOpen: func(_ string) error {
+				return errors.New("browser failed")
+			},
+			wantErr:    true,
+			errMessage: "browser failed",
+		},
+		{
+			name: "empty URL",
+			url:  "",
+			mockOpen: func(url string) error {
+				if url != "" {
+					t.Errorf("Expected empty URL, got %s", url)
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockBrowser := &MockBrowser{openFunc: tt.mockOpen}
+			launcher := NewDefaultBrowserLauncherWithBrowser(mockBrowser)
+
+			err := launcher.OpenURL(tt.url)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("OpenURL() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errMessage != "" && err.Error() != tt.errMessage {
+					t.Errorf("OpenURL() error = %v, want %v", err.Error(), tt.errMessage)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("OpenURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultBrowserLauncher_Interface(_ *testing.T) {
+	var _ BrowserLauncher = (*DefaultBrowserLauncher)(nil)
+}
+
+func TestNewDefaultBrowserLauncher(t *testing.T) {
+	launcher := NewDefaultBrowserLauncher()
+	if launcher == nil {
+		t.Error("NewDefaultBrowserLauncher() returned nil")
+		return
+	}
+	if launcher.browser == nil {
+		t.Error("NewDefaultBrowserLauncher() browser is nil")
+	}
+}
+
+func TestNewDefaultBrowserLauncherWithBrowser(t *testing.T) {
+	mockBrowser := &MockBrowser{}
+	launcher := NewDefaultBrowserLauncherWithBrowser(mockBrowser)
+
+	if launcher == nil {
+		t.Error("NewDefaultBrowserLauncherWithBrowser() returned nil")
+		return
+	}
+	if launcher.browser != mockBrowser {
+		t.Error("NewDefaultBrowserLauncherWithBrowser() did not set the provided browser")
+	}
+}

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -22,7 +22,8 @@ type Config struct {
 
 // Client is a wrapper around http.Client with utility methods
 type Client struct {
-	client *http.Client
+	client   *http.Client
+	authDeps *AuthFlowDependencies // Optional dependencies for authorization flows
 }
 
 // Response represents an HTTP response with convenience methods
@@ -58,6 +59,15 @@ func NewClient(cfg *Config) *Client {
 			Transport: transport,
 			Timeout:   cfg.Timeout,
 		},
+		authDeps: NewAuthFlowDependencies(), // Initialize with default dependencies
+	}
+}
+
+// SetAuthFlowDependencies sets custom dependencies for authorization flows.
+// This is primarily used for testing with mock implementations.
+func (c *Client) SetAuthFlowDependencies(deps *AuthFlowDependencies) {
+	if deps != nil {
+		c.authDeps = deps
 	}
 }
 

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -411,7 +411,7 @@ func TestDo_ResponseBodyCloseError(t *testing.T) {
 	})
 
 	_, err := client.Do(context.Background(), http.MethodGet, ts.URL, nil, nil)
-	
+
 	// Verify that the close error is properly propagated
 	if err == nil {
 		t.Error("Expected error from failing to close response body, but got nil")

--- a/httpclient/response_validator.go
+++ b/httpclient/response_validator.go
@@ -1,0 +1,45 @@
+package httpclient
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+// DefaultResponseValidator implements ResponseValidator using the existing validation logic.
+type DefaultResponseValidator struct{}
+
+// Ensure DefaultResponseValidator implements the interface.
+var _ ResponseValidator = (*DefaultResponseValidator)(nil)
+
+// ValidateResponse validates the callback response and returns the authorization code response.
+func (v *DefaultResponseValidator) ValidateResponse(req *AuthorizationCodeRequest, resp *webflow.CallbackResponse) (*AuthorizationCodeResponse, error) {
+	if req == nil {
+		return nil, errors.New("request cannot be nil")
+	}
+	if resp == nil {
+		return nil, errors.New("response cannot be nil")
+	}
+
+	// Validate state parameter to prevent CSRF attacks
+	if req.State != "" && resp.State != req.State {
+		return nil, fmt.Errorf("state mismatch: expected %q but got %q", req.State, resp.State)
+	}
+
+	// Check for authorization errors
+	if resp.Code == "" {
+		return nil, fmt.Errorf("authorization failed with error %s and description %s", resp.ErrorMsg, resp.ErrorDescription)
+	}
+
+	// Build the successful response
+	return &AuthorizationCodeResponse{
+		Code: resp.Code,
+		State: func() string {
+			if req.State != "" {
+				return req.State
+			}
+			return ""
+		}(),
+	}, nil
+}

--- a/httpclient/response_validator_test.go
+++ b/httpclient/response_validator_test.go
@@ -1,0 +1,178 @@
+package httpclient
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+func TestDefaultResponseValidator_ValidateResponse(t *testing.T) {
+	validator := &DefaultResponseValidator{}
+
+	tests := []struct {
+		name        string
+		req         *AuthorizationCodeRequest
+		resp        *webflow.CallbackResponse
+		want        *AuthorizationCodeResponse
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "successful response with state",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				State:    "test-state",
+			},
+			resp: &webflow.CallbackResponse{
+				Code:  "auth-code-123",
+				State: "test-state",
+			},
+			want: &AuthorizationCodeResponse{
+				Code:  "auth-code-123",
+				State: "test-state",
+			},
+			wantErr: false,
+		},
+		{
+			name: "successful response without state",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+			},
+			resp: &webflow.CallbackResponse{
+				Code:  "auth-code-123",
+				State: "some-state",
+			},
+			want: &AuthorizationCodeResponse{
+				Code:  "auth-code-123",
+				State: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "state mismatch",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				State:    "expected-state",
+			},
+			resp: &webflow.CallbackResponse{
+				Code:  "auth-code-123",
+				State: "different-state",
+			},
+			wantErr:     true,
+			errContains: "state mismatch: expected \"expected-state\" but got \"different-state\"",
+		},
+		{
+			name: "missing authorization code",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				State:    "test-state",
+			},
+			resp: &webflow.CallbackResponse{
+				State:            "test-state",
+				ErrorMsg:         "access_denied",
+				ErrorDescription: "User denied the request",
+			},
+			wantErr:     true,
+			errContains: "authorization failed with error access_denied and description User denied the request",
+		},
+		{
+			name: "missing authorization code with empty error",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+			},
+			resp: &webflow.CallbackResponse{
+				// No code, no error details
+			},
+			wantErr:     true,
+			errContains: "authorization failed with error  and description ",
+		},
+		{
+			name:        "nil request",
+			req:         nil,
+			resp:        &webflow.CallbackResponse{Code: "test-code"},
+			wantErr:     true,
+			errContains: "request cannot be nil",
+		},
+		{
+			name: "nil response",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+			},
+			resp:        nil,
+			wantErr:     true,
+			errContains: "response cannot be nil",
+		},
+		{
+			name: "empty state in request allows any callback state",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				State:    "",
+			},
+			resp: &webflow.CallbackResponse{
+				Code:  "auth-code-123",
+				State: "any-state",
+			},
+			want: &AuthorizationCodeResponse{
+				Code:  "auth-code-123",
+				State: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "both states empty",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				State:    "",
+			},
+			resp: &webflow.CallbackResponse{
+				Code:  "auth-code-123",
+				State: "",
+			},
+			want: &AuthorizationCodeResponse{
+				Code:  "auth-code-123",
+				State: "",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validator.ValidateResponse(tt.req, tt.resp)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateResponse() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("ValidateResponse() error = %v, want error containing %v", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ValidateResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got == nil {
+				t.Error("ValidateResponse() returned nil result")
+				return
+			}
+
+			if got.Code != tt.want.Code {
+				t.Errorf("ValidateResponse() Code = %v, want %v", got.Code, tt.want.Code)
+			}
+
+			if got.State != tt.want.State {
+				t.Errorf("ValidateResponse() State = %v, want %v", got.State, tt.want.State)
+			}
+		})
+	}
+}
+
+func TestDefaultResponseValidator_Interface(_ *testing.T) {
+	var _ ResponseValidator = (*DefaultResponseValidator)(nil)
+}

--- a/httpclient/server_manager.go
+++ b/httpclient/server_manager.go
@@ -1,0 +1,70 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+// DefaultCallbackServerManager implements CallbackServerManager using the existing server logic.
+type DefaultCallbackServerManager struct{}
+
+// Ensure DefaultCallbackServerManager implements the interface.
+var _ CallbackServerManager = (*DefaultCallbackServerManager)(nil)
+
+const (
+	defaultServerTimeout = 5 * time.Minute        // Default timeout for server startup
+	defaultStartDelay    = 100 * time.Millisecond // Delay to allow server to start
+)
+
+// StartServer creates and starts a callback server, returning it for later use.
+func (m *DefaultCallbackServerManager) StartServer(ctx context.Context, callback string) (*webflow.CallbackServer, error) {
+	if callback == "" {
+		return nil, errors.New("callback URL is required")
+	}
+
+	callbackServer, err := webflow.NewCallbackServer(callback)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create callback server: %w", err)
+	}
+
+	// Create a timeout context for server startup
+	startupCtx, cancel := context.WithTimeout(ctx, defaultServerTimeout)
+	defer cancel()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		if err := callbackServer.Start(startupCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrChan <- err
+		}
+	}()
+
+	// Give the server a moment to start or fail
+	select {
+	case err := <-serverErrChan:
+		return nil, fmt.Errorf("callback server failed to start: %w", err)
+	case <-startupCtx.Done():
+		return nil, startupCtx.Err()
+	case <-time.After(defaultStartDelay):
+		// Server started successfully
+		return callbackServer, nil
+	}
+}
+
+// WaitForCallback waits for the OAuth callback response from the server.
+func (m *DefaultCallbackServerManager) WaitForCallback(ctx context.Context, server *webflow.CallbackServer) (*webflow.CallbackResponse, error) {
+	if server == nil {
+		return nil, errors.New("server cannot be nil")
+	}
+
+	callbackResp, err := server.WaitForCallback(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("callback failed: %w", err)
+	}
+
+	return callbackResp, nil
+}

--- a/httpclient/server_manager_test.go
+++ b/httpclient/server_manager_test.go
@@ -1,0 +1,190 @@
+package httpclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jentz/oidc-cli/webflow"
+)
+
+func TestDefaultCallbackServerManager_StartServer(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+
+	tests := []struct {
+		name        string
+		callback    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid callback URL",
+			callback: "http://localhost:0/callback", // Use port 0 for any available port
+			wantErr:  false,
+		},
+		{
+			name:        "empty callback URL",
+			callback:    "",
+			wantErr:     true,
+			errContains: "callback URL is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			server, err := manager.StartServer(ctx, tt.callback)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("StartServer() error = nil, wantErr %v", tt.wantErr)
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("StartServer() error = %v, want error containing %v", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("StartServer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if server == nil {
+				t.Error("StartServer() returned nil server")
+			}
+		})
+	}
+}
+
+func TestDefaultCallbackServerManager_StartServer_InvalidURL(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// Test with a URL that will fail during URL parsing
+	server, err := manager.StartServer(ctx, "ht tp://invalid")
+
+	if err == nil {
+		t.Error("StartServer() should fail with invalid URL")
+	}
+	if server != nil {
+		t.Error("StartServer() should return nil server on error")
+	}
+	if !strings.Contains(err.Error(), "failed to create callback server") {
+		t.Errorf("StartServer() error should contain 'failed to create callback server', got: %v", err)
+	}
+}
+
+func TestDefaultCallbackServerManager_StartServer_ContextCanceled(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+
+	// Create a context that's already canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	server, err := manager.StartServer(ctx, "http://localhost:0/callback")
+
+	if err == nil {
+		t.Error("StartServer() should fail with canceled context")
+	}
+	if server != nil {
+		t.Error("StartServer() should return nil server on error")
+	}
+}
+
+func TestDefaultCallbackServerManager_WaitForCallback(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+
+	tests := []struct {
+		name        string
+		server      *webflow.CallbackServer
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "nil server",
+			server:      nil,
+			wantErr:     true,
+			errContains: "server cannot be nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			resp, err := manager.WaitForCallback(ctx, tt.server)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("WaitForCallback() error = nil, wantErr %v", tt.wantErr)
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("WaitForCallback() error = %v, want error containing %v", err, tt.errContains)
+				}
+				if resp != nil {
+					t.Error("WaitForCallback() should return nil response on error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("WaitForCallback() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultCallbackServerManager_WaitForCallback_Timeout(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+
+	// Create a server but don't send any callback
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	server, err := manager.StartServer(ctx, "http://localhost:0/callback")
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+
+	// Create a very short timeout context for waiting
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer waitCancel()
+
+	resp, err := manager.WaitForCallback(waitCtx, server)
+
+	if err == nil {
+		t.Error("WaitForCallback() should timeout")
+	}
+	if resp != nil {
+		t.Error("WaitForCallback() should return nil response on timeout")
+	}
+	if !strings.Contains(err.Error(), "callback failed") {
+		t.Errorf("WaitForCallback() error should contain 'callback failed', got: %v", err)
+	}
+}
+
+func TestDefaultCallbackServerManager_Interface(_ *testing.T) {
+	var _ CallbackServerManager = (*DefaultCallbackServerManager)(nil)
+}
+
+// Integration test to verify the full server lifecycle
+func TestDefaultCallbackServerManager_Integration(t *testing.T) {
+	manager := &DefaultCallbackServerManager{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Start server
+	server, err := manager.StartServer(ctx, "http://localhost:0/callback") // Use port 0 for any available port
+	if err != nil {
+		t.Fatalf("Failed to start server: %v", err)
+	}
+
+	if server == nil {
+		t.Fatal("Server should not be nil")
+	}
+}

--- a/httpclient/url_builder.go
+++ b/httpclient/url_builder.go
@@ -1,0 +1,34 @@
+package httpclient
+
+import (
+	"errors"
+	"fmt"
+)
+
+// DefaultAuthorizationURLBuilder implements AuthorizationURLBuilder using the existing logic.
+type DefaultAuthorizationURLBuilder struct{}
+
+// Ensure DefaultAuthorizationURLBuilder implements the interface.
+var _ AuthorizationURLBuilder = (*DefaultAuthorizationURLBuilder)(nil)
+
+// BuildAuthorizationURL creates a complete authorization URL from the endpoint and request parameters.
+func (b *DefaultAuthorizationURLBuilder) BuildAuthorizationURL(endpoint string, req *AuthorizationCodeRequest) (string, error) {
+	if endpoint == "" {
+		return "", errors.New("endpoint is required")
+	}
+	if req == nil {
+		return "", errors.New("request cannot be nil")
+	}
+
+	values, err := CreateAuthorizationCodeRequestValues(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to create authorization request values: %w", err)
+	}
+
+	requestURL, err := CreateAuthorizationCodeRequestURL(endpoint, values)
+	if err != nil {
+		return "", fmt.Errorf("failed to create authorization request URL: %w", err)
+	}
+
+	return requestURL, nil
+}

--- a/httpclient/url_builder_test.go
+++ b/httpclient/url_builder_test.go
@@ -1,0 +1,116 @@
+package httpclient
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultAuthorizationURLBuilder_BuildAuthorizationURL(t *testing.T) {
+	builder := &DefaultAuthorizationURLBuilder{}
+
+	tests := []struct {
+		name        string
+		endpoint    string
+		req         *AuthorizationCodeRequest
+		want        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid request",
+			endpoint: "https://example.com/auth",
+			req: &AuthorizationCodeRequest{
+				ClientID:    "test-client",
+				RedirectURI: "http://localhost:8080/callback",
+				Scope:       "openid profile",
+				State:       "test-state",
+			},
+			want:    "https://example.com/auth?client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback&response_type=code&scope=openid+profile&state=test-state",
+			wantErr: false,
+		},
+		{
+			name:        "empty endpoint",
+			endpoint:    "",
+			req:         &AuthorizationCodeRequest{ClientID: "test-client"},
+			wantErr:     true,
+			errContains: "endpoint is required",
+		},
+		{
+			name:        "nil request",
+			endpoint:    "https://example.com/auth",
+			req:         nil,
+			wantErr:     true,
+			errContains: "request cannot be nil",
+		},
+		{
+			name:        "empty client ID",
+			endpoint:    "https://example.com/auth",
+			req:         &AuthorizationCodeRequest{},
+			wantErr:     true,
+			errContains: "client_id is required",
+		},
+		{
+			name:     "with PKCE parameters",
+			endpoint: "https://example.com/auth",
+			req: &AuthorizationCodeRequest{
+				ClientID:            "test-client",
+				CodeChallenge:       "test-challenge",
+				CodeChallengeMethod: "S256",
+			},
+			want:    "https://example.com/auth?client_id=test-client&code_challenge=test-challenge&code_challenge_method=S256&response_type=code",
+			wantErr: false,
+		},
+		{
+			name:     "with custom args",
+			endpoint: "https://example.com/auth",
+			req: &AuthorizationCodeRequest{
+				ClientID: "test-client",
+				CustomArgs: &CustomArgs{
+					"custom_param": "custom_value",
+					"another":      "value",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := builder.BuildAuthorizationURL(tt.endpoint, tt.req)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("BuildAuthorizationURL() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("BuildAuthorizationURL() error = %v, want error containing %v", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("BuildAuthorizationURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.want != "" && got != tt.want {
+				t.Errorf("BuildAuthorizationURL() = %v, want %v", got, tt.want)
+			}
+
+			// For custom args test, just verify it doesn't error and contains expected parts
+			if tt.req != nil && tt.req.CustomArgs != nil {
+				if !strings.Contains(got, "custom_param=custom_value") {
+					t.Errorf("BuildAuthorizationURL() = %v, should contain custom_param=custom_value", got)
+				}
+				if !strings.Contains(got, "another=value") {
+					t.Errorf("BuildAuthorizationURL() = %v, should contain another=value", got)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultAuthorizationURLBuilder_Interface(_ *testing.T) {
+	var _ AuthorizationURLBuilder = (*DefaultAuthorizationURLBuilder)(nil)
+}

--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -5,10 +5,10 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"html/template"
 	"net"
 	"net/http"
 	"net/url"
-	"html/template"
 	"time"
 
 	"github.com/jentz/oidc-cli/log"


### PR DESCRIPTION
- Added CallbackServerManager interface and DefaultCallbackServerManager implementation for managing OAuth callback servers.
- Introduced AuthorizationURLBuilder interface and DefaultAuthorizationURLBuilder for constructing authorization URLs.
- Created ResponseValidator interface and DefaultResponseValidator for validating OAuth callback responses.
- Implemented BrowserLauncher interface with DefaultBrowserLauncher for opening URLs in the default browser.
- Refactored Client to support dependency injection for authorization flow components.
- Added integration tests for the new components to ensure proper functionality and error handling.