### PR TITLE
fix: startupCtx cancellation interrupts flow

### DIFF
--- a/httpclient/server_manager.go
+++ b/httpclient/server_manager.go
@@ -38,7 +38,7 @@ func (m *DefaultCallbackServerManager) StartServer(ctx context.Context, callback
 
 	serverErrChan := make(chan error, 1)
 	go func() {
-		if err := callbackServer.Start(startupCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := callbackServer.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErrChan <- err
 		}
 	}()


### PR DESCRIPTION
The startCtx is being cancelled in such a way that the server listener for the auth code flow is shutdown prematurely. This is a temporary fix that disables the 5 minutes timeout on the server by simply using the outer ctx.