### PR TITLE
feature: support token exchange

### DIFF
--- a/cmd/command_runner.go
+++ b/cmd/command_runner.go
@@ -28,7 +28,8 @@ var commands = []Command{
 	{Name: "authorization_code", Help: "Use the Authorization Code flow to obtain tokens.", Configure: parseAuthorizationCodeFlags},
 	{Name: "client_credentials", Help: "Use the Client Credentials flow to obtain tokens.", Configure: parseClientCredentialsFlags},
 	{Name: "introspect", Help: "Validate a token and retrieve associated claims.", Configure: parseIntrospectFlags},
-	{Name: "token_refresh", Help: "Exchange a refresh token for new tokens.", Configure: parseTokenRefreshFlags},
+	{Name: "token_refresh", Help: "Use a refresh token to obtain new tokens.", Configure: parseTokenRefreshFlags},
+	{Name: "token_exchange", Help: "Exchange a token for different tokens.", Configure: parseTokenExchangeFlags},
 	{Name: "version", Help: "Display the current version of oidc-cli."},
 	{Name: "help", Help: "Show help for oidc-cli or a specific command."},
 }

--- a/cmd/token_exchange_cfg.go
+++ b/cmd/token_exchange_cfg.go
@@ -19,7 +19,7 @@ func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config) 
 	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret")
 	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 	flags.StringVar(&oidcConf.DPoPPrivateKeyFile, "dpop-private-key", "", "file to read private key from (eg. for DPoP)")
 	flags.StringVar(&oidcConf.DPoPPublicKeyFile, "dpop-public-key", "", "file to read public key from (eg. for DPoP)")
@@ -68,10 +68,6 @@ func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config) 
 		{
 			oidcConf.ClientID == "",
 			"client-id is required",
-		},
-		{
-			oidcConf.ClientSecret == "",
-			"client-secret is required",
 		},
 		{
 			flowConf.SubjectToken == "",

--- a/cmd/token_exchange_cfg.go
+++ b/cmd/token_exchange_cfg.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/jentz/oidc-cli/oidc"
+)
+
+func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+
+	flags.StringVar(&oidcConf.IssuerURL, "issuer", oidcConf.IssuerURL, "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
+	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
+	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required)")
+	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
+	flags.StringVar(&oidcConf.DPoPPrivateKeyFile, "dpop-private-key", "", "file to read private key from (eg. for DPoP)")
+	flags.StringVar(&oidcConf.DPoPPublicKeyFile, "dpop-public-key", "", "file to read public key from (eg. for DPoP)")
+
+	var flowConf oidc.TokenExchangeFlowConfig
+	flags.StringVar(&flowConf.SubjectToken, "subject-token", "", "subject token to be exchanged (required)")
+	flags.StringVar(&flowConf.SubjectTokenType, "subject-token-type", "urn:ietf:params:oauth:token-type:access_token", "subject token type to be used for the exchange")
+	flags.StringVar(&flowConf.Audience, "audience", "", "audience to be used for the token exchange")
+	flags.StringVar(&flowConf.Scope, "scope", "", "scope to be used for the token exchange")
+	flags.StringVar(&flowConf.RequestedTokenType, "requested-token-type", "", "requested token type to be used for the exchange (eg. 'urn:ietf:params:oauth:token-type:access_token')")
+	flags.StringVar(&flowConf.Resource, "resource", "", "resource to be used for the token exchange")
+	flags.StringVar(&flowConf.ActorToken, "actor-token", "", "actor token to be used for the token exchange")
+	flags.StringVar(&flowConf.ActorTokenType, "actor-token-type", "", "actor token type to be used for the exchange (eg. 'urn:ietf:params:oauth:token-type:access_token')")
+	flags.BoolVar(&flowConf.DPoP, "dpop", false, "use DPoP-bound access tokens")
+
+	runner = &oidc.TokenExchangeFlow{
+		Config:     oidcConf,
+		FlowConfig: &flowConf,
+	}
+
+	err = flags.Parse(args)
+	if err != nil {
+		return nil, buf.String(), err
+	}
+
+	// Read subject token from stdin if token equals '-'
+	if flowConf.SubjectToken == "-" {
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return nil, buf.String(), err
+			}
+			return nil, buf.String(), errors.New("no subject token provided on stdin")
+		}
+		flowConf.SubjectToken = scanner.Text()
+	}
+
+	var invalidArgsChecks = []struct {
+		condition bool
+		message   string
+	}{
+		{
+			oidcConf.IssuerURL == "",
+			"issuer is required",
+		},
+		{
+			oidcConf.ClientID == "",
+			"client-id is required",
+		},
+		{
+			oidcConf.ClientSecret == "",
+			"client-secret is required",
+		},
+		{
+			flowConf.SubjectToken == "",
+			"subject token is required",
+		},
+		{
+			flowConf.DPoP && (oidcConf.DPoPPrivateKeyFile == "" || oidcConf.DPoPPublicKeyFile == ""),
+			"both dpop-private-key and dpop-public-key are required when using DPoP",
+		},
+	}
+
+	for _, check := range invalidArgsChecks {
+		if check.condition {
+			return nil, check.message, errors.New("invalid arguments: " + check.message)
+		}
+	}
+
+	return runner, buf.String(), nil
+}

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -57,6 +57,22 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 				DPoP:               true,
 			},
 		},
+		{
+			"minimum required flags",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--subject-token", "subject-token",
+			},
+			oidc.Config{
+				IssuerURL:         "https://example.com",
+				ClientID:          "client-id",
+			},
+			oidc.TokenExchangeFlowConfig{
+				SubjectToken:     "subject-token",
+				SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -103,14 +119,6 @@ func TestParseTokenExchangeFlagsError(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			"invalid arguments: client-id is required",
-		},
-		{
-			"missing client-secret",
-			[]string{
-				"--issuer", "https://example.com",
-				"--client-id", "client-id",
-			},
-			"invalid arguments: client-secret is required",
 		},
 		{
 			"missing subject token",

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -65,8 +65,8 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 				"--subject-token", "subject-token",
 			},
 			oidc.Config{
-				IssuerURL:         "https://example.com",
-				ClientID:          "client-id",
+				IssuerURL: "https://example.com",
+				ClientID:  "client-id",
 			},
 			oidc.TokenExchangeFlowConfig{
 				SubjectToken:     "subject-token",

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"flag"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/jentz/oidc-cli/oidc"
+)
+
+func TestParseTokenExchangeFlagsResult(t *testing.T) {
+	var tests = []struct {
+		name     string
+		args     []string
+		oidcConf oidc.Config
+		flowConf oidc.TokenExchangeFlowConfig
+	}{
+		{
+			"all flags",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--introspection-url", "https://example.com/introspection",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--subject-token", "subject-token",
+				"--subject-token-type", "subject-token-type",
+				"--actor-token", "actor-token",
+				"--actor-token-type", "actor-token-type",
+				"--audience", "audience",
+				"--scope", "scope",
+				"--requested-token-type", "requested-token-type",
+				"--resource", "resource",
+				"--dpop",
+				"--dpop-private-key", "path/to/private-key.pem",
+				"--dpop-public-key", "path/to/public-key.pem",
+			},
+			oidc.Config{
+				IssuerURL:             "https://example.com",
+				DiscoveryEndpoint:     "https://example.com/.well-known/openid-configuration",
+				IntrospectionEndpoint: "https://example.com/introspection",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+				DPoPPrivateKeyFile:    "path/to/private-key.pem",
+				DPoPPublicKeyFile:     "path/to/public-key.pem",
+			},
+			oidc.TokenExchangeFlowConfig{
+				Resource:           "resource",
+				Audience:           "audience",
+				Scope:              "scope",
+				RequestedTokenType: "requested-token-type",
+				SubjectToken:       "subject-token",
+				SubjectTokenType:   "subject-token-type",
+				ActorToken:         "actor-token",
+				ActorTokenType:     "actor-token-type",
+				DPoP:               true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{})
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			f, ok := runner.(*oidc.TokenExchangeFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+			}
+			if !reflect.DeepEqual(*f.Config, tt.oidcConf) {
+				t.Errorf("Config got %+v, want %+v", *f.Config, tt.oidcConf)
+			}
+			if !reflect.DeepEqual(*f.FlowConfig, tt.flowConf) {
+				t.Errorf("FlowConfig got %+v, want %+v", *f.FlowConfig, tt.flowConf)
+			}
+		})
+	}
+}
+
+func TestParseTokenExchangeFlagsError(t *testing.T) {
+	var tests = []struct {
+		name          string
+		args          []string
+		expectedError string
+	}{
+		{
+			"missing issuer",
+			[]string{
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			"invalid arguments: issuer is required",
+		},
+		{
+			"missing client-id",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-secret", "client-secret",
+			},
+			"invalid arguments: client-id is required",
+		},
+		{
+			"missing client-secret",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+			},
+			"invalid arguments: client-secret is required",
+		},
+		{
+			"missing subject token",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			"invalid arguments: subject token is required",
+		},
+		{
+			"undefined argument provided",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--undefined-argument", "undefined-argument",
+				"--subject-token", "subject-token",
+			},
+			"flag provided but not defined: -undefined-argument",
+		},
+		{
+			"help flag",
+			[]string{
+				"--help",
+			},
+			flag.ErrHelp.Error(),
+		},
+		{
+			"missing private-key and dpop",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--subject-token", "subject-token",
+				"--dpop",
+				"--dpop-public-key", "path/to/public-key.pem",
+			},
+			"invalid arguments: both dpop-private-key and dpop-public-key are required when using DPoP",
+		},
+		{
+			"missing public-key and dpop",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--subject-token", "subject-token",
+				"--dpop",
+				"--dpop-private-key", "path/to/private-key.pem",
+			},
+			"invalid arguments: both dpop-private-key and dpop-public-key are required when using DPoP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{})
+			if err == nil {
+				t.Errorf("err got nil, want error")
+			}
+			if output == "" {
+				t.Errorf("output got empty, want error message")
+			}
+			if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("err got %v, want %v", err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestParseTokenExchangeFlagsStdin(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectError   bool
+		expectedToken string
+	}{
+		{
+			name:          "successful stdin read",
+			input:         "test-subject-token\n",
+			expectError:   false,
+			expectedToken: "test-subject-token",
+		},
+		{
+			name:        "empty input (EOF)",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:          "whitespace only input",
+			input:         "   \n",
+			expectError:   false,
+			expectedToken: "   ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original stdin
+			originalStdin := os.Stdin
+			defer func() { os.Stdin = originalStdin }()
+
+			// Create pipe to simulate stdin
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("Failed to create pipe: %v", err)
+			}
+			os.Stdin = r
+
+			// Write test input to pipe
+			go func() {
+				defer func() { _ = w.Close() }()
+				if tt.input != "" {
+					_, _ = w.WriteString(tt.input)
+				}
+			}()
+
+			args := []string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--subject-token", "-", // This triggers stdin reading
+				"--subject-token-type", "subject-token-type",
+			}
+
+			runner, output, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{})
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+
+			f, ok := runner.(*oidc.TokenExchangeFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+				return
+			}
+
+			if f.FlowConfig.SubjectToken != tt.expectedToken {
+				t.Errorf("SubjectToken got %q, want %q", f.FlowConfig.SubjectToken, tt.expectedToken)
+			}
+		})
+	}
+}
+
+func TestParseTokenExchangeFlagsStdinError(t *testing.T) {
+	// Save original stdin
+	originalStdin := os.Stdin
+	defer func() { os.Stdin = originalStdin }()
+
+	expectedError := "no subject token provided on stdin"
+
+	// Test the EOF case (no input) - this should return flag.ErrHelp
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	_ = w.Close() // Close write end immediately to simulate EOF
+	os.Stdin = r
+	defer func() { _ = r.Close() }()
+
+	args := []string{
+		"--issuer", "https://example.com",
+		"--client-id", "client-id",
+		"--client-secret", "client-secret",
+		"--subject-token", "-", // This triggers stdin reading
+		"--subject-token-type", "subject-token-type",
+	}
+
+	_, _, err = parseTokenExchangeFlags("token_exchange", args, &oidc.Config{})
+	if err == nil {
+		t.Error("expected error from empty stdin, got nil")
+	}
+	if err.Error() != expectedError {
+		t.Errorf("expected error message %v, got %v", expectedError, err)
+	}
+}

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -16,6 +16,19 @@ type TokenRequest struct {
 	Params       url.Values
 }
 
+// TokenExchangeInput is used to construct the parameters of a token exchange request
+type TokenExchangeInput struct {
+	GrantType          string
+	Resource           string
+	Audience           string
+	Scope              string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+	ActorToken         string
+	ActorTokenType     string
+}
+
 // ExecuteTokenRequest sends a token request to the specified endpoint
 func (c *Client) ExecuteTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, headers map[string]string) (*Response, error) {
 	if req.Params == nil {
@@ -108,6 +121,43 @@ func CreateDeviceCodeTokenRequest(clientID, clientSecret string, authMethod Auth
 
 	return &TokenRequest{
 		GrantType:    "urn:ietf:params:oauth:grant-type:device_code",
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		AuthMethod:   authMethod,
+		Params:       params,
+	}
+}
+
+// CreateTokenExchangeRequest creates a token request for the token exchange grant
+func CreateTokenExchangeRequest(clientID, clientSecret string, authMethod AuthMethod, input TokenExchangeInput) *TokenRequest {
+	params := url.Values{}
+
+	// Required parameters
+	params.Set("subject_token", input.SubjectToken)
+	params.Set("subject_token_type", input.SubjectTokenType)
+
+	// Optional parameters
+	if input.Resource != "" {
+		params.Set("resource", input.Resource)
+	}
+	if input.Audience != "" {
+		params.Set("audience", input.Audience)
+	}
+	if input.Scope != "" {
+		params.Set("scope", input.Scope)
+	}
+	if input.RequestedTokenType != "" {
+		params.Set("requested_token_type", input.RequestedTokenType)
+	}
+	if input.ActorToken != "" {
+		params.Set("actor_token", input.ActorToken)
+	}
+	if input.ActorTokenType != "" {
+		params.Set("actor_token_type", input.ActorTokenType)
+	}
+
+	return &TokenRequest{
+		GrantType:    "urn:ietf:params:oauth:grant-type:token-exchange",
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		AuthMethod:   authMethod,

--- a/oidc/token_exchange.go
+++ b/oidc/token_exchange.go
@@ -1,0 +1,104 @@
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jentz/oidc-cli/crypto"
+	"github.com/jentz/oidc-cli/httpclient"
+	"github.com/jentz/oidc-cli/log"
+)
+
+type TokenExchangeFlow struct {
+	Config     *Config
+	FlowConfig *TokenExchangeFlowConfig
+}
+
+type TokenExchangeFlowConfig struct {
+	Resource           string
+	Audience           string
+	Scope              string
+	RequestedTokenType string
+	SubjectToken       string
+	SubjectTokenType   string
+	ActorToken         string
+	ActorTokenType     string
+	DPoP               bool
+}
+
+func (c *TokenExchangeFlow) createTokenRequest() *httpclient.TokenRequest {
+	input := httpclient.TokenExchangeInput{
+		Resource:           c.FlowConfig.Resource,
+		Audience:           c.FlowConfig.Audience,
+		Scope:              c.FlowConfig.Scope,
+		RequestedTokenType: c.FlowConfig.RequestedTokenType,
+		SubjectToken:       c.FlowConfig.SubjectToken,
+		SubjectTokenType:   c.FlowConfig.SubjectTokenType,
+		ActorToken:         c.FlowConfig.ActorToken,
+		ActorTokenType:     c.FlowConfig.ActorTokenType,
+	}
+
+	req := httpclient.CreateTokenExchangeRequest(
+		c.Config.ClientID,
+		c.Config.ClientSecret,
+		c.Config.AuthMethod,
+		input)
+
+	return req
+}
+
+func (c *TokenExchangeFlow) executeTokenRequest(ctx context.Context, tokenRequest *httpclient.TokenRequest, headers map[string]string) (map[string]any, error) {
+	resp, err := c.Config.Client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, tokenRequest, headers)
+	if err != nil {
+		return nil, fmt.Errorf("token request failed: %w", err)
+	}
+
+	tokenData, err := httpclient.ParseTokenResponse(resp)
+	if err != nil {
+		return nil, httpclient.WrapError(err, "token")
+	}
+
+	return tokenData, nil
+}
+
+func (c *TokenExchangeFlow) setupDPoPHeaders() (map[string]string, error) {
+	headers := make(map[string]string)
+	if c.FlowConfig.DPoP {
+		dpopProof, err := crypto.NewDPoPProof(
+			c.Config.DPoPPublicKey,
+			c.Config.DPoPPrivateKey,
+			"POST",
+			c.Config.TokenEndpoint,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create DPoP proof: %w", err)
+		}
+		headers["DPoP"] = dpopProof.String()
+	}
+	return headers, nil
+}
+
+func (c *TokenExchangeFlow) Run(ctx context.Context) error {
+	req := c.createTokenRequest()
+
+	// Handle DPoP
+	headers, err := c.setupDPoPHeaders()
+	if err != nil {
+		return err
+	}
+
+	// Call the token endpoint with the token exchange request
+	tokenData, err := c.executeTokenRequest(ctx, req, headers)
+	if err != nil {
+		return err
+	}
+
+	// Print available response data
+	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format token response: %w", err)
+	}
+	log.Outputf("%s\n", string(prettyJSON))
+	return nil
+}


### PR DESCRIPTION
This adds a token exchange command which can be used to execute the token exchange flow. Supports all token exchange parameters as specified in RFC8693. The subject token is mandatory and can be provided either on the command line or through stdin, similar to how the refresh token command has been implemented previously.