### PR TITLE
Use http.DefaultTransport to support HTTP proxy from environment

### DIFF
--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -47,11 +47,18 @@ func NewClient(cfg *Config) *Client {
 
 	transport := cfg.Transport
 	if transport == nil {
-		transport = &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: cfg.SkipTLSVerify,
-			},
+		transport = http.DefaultTransport
+	}
+
+	if httpTransport, ok := transport.(*http.Transport); ok {
+		httpTransport = httpTransport.Clone()
+		tlsClientConfig := httpTransport.TLSClientConfig.Clone()
+		if tlsClientConfig == nil {
+			tlsClientConfig = &tls.Config{}
 		}
+		tlsClientConfig.InsecureSkipVerify = cfg.SkipTLSVerify
+		httpTransport.TLSClientConfig = tlsClientConfig
+		transport = httpTransport
 	}
 
 	return &Client{


### PR DESCRIPTION
Use a clone of `http.DefaultTransport` for new HTTP clients.
The default value of `http.DefaultTransport` uses  `http.ProxyFromEnvrionment` that uses proxy settings from  `HTTP_PROXY` , `HTTPS_PROXY`  and `NO_PROXY` environment variables.

My use case for this are:
- Use [mitmproxy](https://www.mitmproxy.org/) to inspect HTTP traffic with the OIDC issuer when developing
- Use HTTP proxy when running tests in isolated environment ( kubernetes cluster) that enforces that all HTTP traffic go through an HTTP proxy for security monitoring and enforcement.