### PR TITLE
fix: remove redundant Go module cache step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,6 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
-  
-      - name: Cache Go modules
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Get dependencies
         run: go mod download


### PR DESCRIPTION
actions/setup-go@v6 has built-in caching enabled by default. The explicit actions/cache@v5 step conflicts by trying to extract into the same ~/go/pkg/mod path, causing tar "File exists" errors on every run.