### PR TITLE
refactor: inject stdin reader into cmd parsers

### DIFF
--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"io"
 
 	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/oidc"
@@ -20,7 +21,7 @@ func (c *CustomArgsFlag) Set(value string) error {
 	return nil
 }
 
-func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/httpclient"
@@ -251,7 +252,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{})
+			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -321,7 +322,7 @@ func TestParseAuthorizationCodeFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{})
+			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"os"
 
 	"github.com/jentz/oidc-cli/log"
 )
@@ -44,7 +45,7 @@ func CLI(args []string, logOptions ...log.Option) int {
 
 	subCmd := args[0]
 	subCmdArgs := args[1:]
-	return RunCommand(subCmd, subCmdArgs, globalConf, logger)
+	return RunCommand(subCmd, subCmdArgs, globalConf, logger, os.Stdin)
 }
 
 func usage(logger *log.Logger, flags ...*flag.FlagSet) {

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/oidc"
@@ -77,7 +78,7 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{})
+			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -122,7 +123,7 @@ func TestParseClientCredentialsFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{})
+			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/command_runner.go
+++ b/cmd/command_runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"slices"
@@ -21,7 +22,7 @@ type CommandRunner interface {
 type Command struct {
 	Name      string
 	Help      string
-	Configure func(name string, args []string, cfg *oidc.Config) (config CommandRunner, output string, err error)
+	Configure func(name string, args []string, cfg *oidc.Config, stdin io.Reader) (config CommandRunner, output string, err error)
 }
 
 var commands = []Command{
@@ -35,7 +36,7 @@ var commands = []Command{
 	{Name: "help", Help: "Show help for oidc-cli or a specific command."},
 }
 
-func RunCommand(name string, args []string, globalConf *oidc.Config, logger *log.Logger) int {
+func RunCommand(name string, args []string, globalConf *oidc.Config, logger *log.Logger, stdin io.Reader) int {
 	cmdIdx := slices.IndexFunc(commands, func(cmd Command) bool {
 		return cmd.Name == name
 	})
@@ -57,7 +58,7 @@ func RunCommand(name string, args []string, globalConf *oidc.Config, logger *log
 		return ExitOK
 	}
 
-	command, output, err := cmd.Configure(name, args, globalConf)
+	command, output, err := cmd.Configure(name, args, globalConf, stdin)
 	if errors.Is(err, flag.ErrHelp) {
 		logger.Outputln(output)
 		return ExitHelp

--- a/cmd/device_cfg.go
+++ b/cmd/device_cfg.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"flag"
+	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseDeviceFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseDeviceFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)

--- a/cmd/device_cfg_test.go
+++ b/cmd/device_cfg_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/oidc"
@@ -138,7 +139,7 @@ func TestParseDeviceFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{})
+			runner, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -196,7 +197,7 @@ func TestParseDeviceFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{})
+			_, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -60,6 +60,7 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, std
 			if err := scanner.Err(); err != nil {
 				return nil, buf.String(), err
 			}
+			return nil, buf.String(), errors.New("no token provided on stdin")
 		}
 		flowConf.Token = scanner.Text()
 	}

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -5,13 +5,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"os"
+	"io"
 
 	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
@@ -54,9 +54,8 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (ru
 		}
 	}
 
-	// Read token from stdin if token equals '-'
 	if flowConf.Token == "-" {
-		scanner := bufio.NewScanner(os.Stdin)
+		scanner := bufio.NewScanner(stdin)
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				return nil, buf.String(), err

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -153,6 +153,91 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 	}
 }
 
+func TestParseIntrospectFlagsStdin(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectError   bool
+		expectedToken string
+	}{
+		{
+			name:          "successful stdin read",
+			input:         "test-token\n",
+			expectError:   false,
+			expectedToken: "test-token",
+		},
+		{
+			name:        "empty input (EOF)",
+			input:       "",
+			expectError: true,
+		},
+		{
+			name:          "whitespace only input",
+			input:         "   \n",
+			expectError:   false,
+			expectedToken: "   ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--token", "-", // This triggers stdin reading
+			}
+
+			runner, output, err := parseIntrospectFlags("introspect", args, &oidc.Config{}, strings.NewReader(tt.input))
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+
+			f, ok := runner.(*oidc.IntrospectFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+				return
+			}
+
+			if f.FlowConfig.Token != tt.expectedToken {
+				t.Errorf("Token got %q, want %q", f.FlowConfig.Token, tt.expectedToken)
+			}
+		})
+	}
+}
+
+func TestParseIntrospectFlagsStdinError(t *testing.T) {
+	expectedError := "no token provided on stdin"
+
+	args := []string{
+		"--issuer", "https://example.com",
+		"--client-id", "client-id",
+		"--client-secret", "client-secret",
+		"--token", "-", // This triggers stdin reading
+	}
+
+	_, _, err := parseIntrospectFlags("introspect", args, &oidc.Config{}, strings.NewReader(""))
+	if err == nil {
+		t.Error("expected error from empty stdin, got nil")
+	}
+	if err.Error() != expectedError {
+		t.Errorf("expected error message %v, got %v", expectedError, err)
+	}
+}
+
 func TestParseIntrospectFlagsCustomArgs(t *testing.T) {
 	testArgs := []string{
 		"--issuer", "https://example.com",

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/oidc"
@@ -88,7 +89,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{})
+			runner, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -141,7 +142,7 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{})
+			_, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -161,7 +162,7 @@ func TestParseIntrospectFlagsCustomArgs(t *testing.T) {
 		"--custom", "foo=bar",
 		"--custom", "baz=qux",
 	}
-	runner, output, err := parseIntrospectFlags("introspect", testArgs, &oidc.Config{})
+	runner, output, err := parseIntrospectFlags("introspect", testArgs, &oidc.Config{}, strings.NewReader(""))
 	if err != nil {
 		t.Fatalf("err got %v, want nil", err)
 	}

--- a/cmd/token_exchange_cfg.go
+++ b/cmd/token_exchange_cfg.go
@@ -5,12 +5,12 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"os"
+	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
@@ -45,9 +45,8 @@ func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config) 
 		return nil, buf.String(), err
 	}
 
-	// Read subject token from stdin if token equals '-'
 	if flowConf.SubjectToken == "-" {
-		scanner := bufio.NewScanner(os.Stdin)
+		scanner := bufio.NewScanner(stdin)
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				return nil, buf.String(), err

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"flag"
-	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/oidc"
@@ -77,7 +77,7 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{})
+			runner, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -175,7 +175,7 @@ func TestParseTokenExchangeFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{})
+			_, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -217,25 +217,6 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save original stdin
-			originalStdin := os.Stdin
-			defer func() { os.Stdin = originalStdin }()
-
-			// Create pipe to simulate stdin
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("Failed to create pipe: %v", err)
-			}
-			os.Stdin = r
-
-			// Write test input to pipe
-			go func() {
-				defer func() { _ = w.Close() }()
-				if tt.input != "" {
-					_, _ = w.WriteString(tt.input)
-				}
-			}()
-
 			args := []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -244,7 +225,7 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 				"--subject-token-type", "subject-token-type",
 			}
 
-			runner, output, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{})
+			runner, output, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{}, strings.NewReader(tt.input))
 
 			if tt.expectError {
 				if err == nil {
@@ -276,20 +257,7 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 }
 
 func TestParseTokenExchangeFlagsStdinError(t *testing.T) {
-	// Save original stdin
-	originalStdin := os.Stdin
-	defer func() { os.Stdin = originalStdin }()
-
 	expectedError := "no subject token provided on stdin"
-
-	// Test the EOF case (no input) - this should return flag.ErrHelp
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	_ = w.Close() // Close write end immediately to simulate EOF
-	os.Stdin = r
-	defer func() { _ = r.Close() }()
 
 	args := []string{
 		"--issuer", "https://example.com",
@@ -299,7 +267,7 @@ func TestParseTokenExchangeFlagsStdinError(t *testing.T) {
 		"--subject-token-type", "subject-token-type",
 	}
 
-	_, _, err = parseTokenExchangeFlags("token_exchange", args, &oidc.Config{})
+	_, _, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{}, strings.NewReader(""))
 	if err == nil {
 		t.Error("expected error from empty stdin, got nil")
 	}

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -5,12 +5,12 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"os"
+	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
+func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
@@ -39,9 +39,8 @@ func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config) (
 		return nil, buf.String(), err
 	}
 
-	// Read refresh token from stdin if token equals '-'
 	if flowConf.RefreshToken == "-" {
-		scanner := bufio.NewScanner(os.Stdin)
+		scanner := bufio.NewScanner(stdin)
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				return nil, buf.String(), err

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"flag"
-	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jentz/oidc-cli/oidc"
@@ -89,7 +89,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{})
+			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -178,7 +178,7 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{})
+			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -220,25 +220,6 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save original stdin
-			originalStdin := os.Stdin
-			defer func() { os.Stdin = originalStdin }()
-
-			// Create pipe to simulate stdin
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("Failed to create pipe: %v", err)
-			}
-			os.Stdin = r
-
-			// Write test input to pipe
-			go func() {
-				defer func() { _ = w.Close() }()
-				if tt.input != "" {
-					_, _ = w.WriteString(tt.input)
-				}
-			}()
-
 			args := []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -246,7 +227,7 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 				"--refresh-token", "-", // This triggers stdin reading
 			}
 
-			runner, output, err := parseTokenRefreshFlags("token_refresh", args, &oidc.Config{})
+			runner, output, err := parseTokenRefreshFlags("token_refresh", args, &oidc.Config{}, strings.NewReader(tt.input))
 
 			if tt.expectError {
 				if err == nil {
@@ -278,20 +259,7 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 }
 
 func TestParseTokenRefreshFlagsStdinError(t *testing.T) {
-	// Save original stdin
-	originalStdin := os.Stdin
-	defer func() { os.Stdin = originalStdin }()
-
 	expectedError := "no refresh token provided on stdin"
-
-	// Test the EOF case (no input) - this should return flag.ErrHelp
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	_ = w.Close() // Close write end immediately to simulate EOF
-	os.Stdin = r
-	defer func() { _ = r.Close() }()
 
 	args := []string{
 		"--issuer", "https://example.com",
@@ -300,7 +268,7 @@ func TestParseTokenRefreshFlagsStdinError(t *testing.T) {
 		"--refresh-token", "-", // This triggers stdin reading
 	}
 
-	_, _, err = parseTokenRefreshFlags("token_refresh", args, &oidc.Config{})
+	_, _, err := parseTokenRefreshFlags("token_refresh", args, &oidc.Config{}, strings.NewReader(""))
 	if err == nil {
 		t.Error("expected error from empty stdin, got nil")
 	}


### PR DESCRIPTION
Replace os.Stdin reads in parseIntrospectFlags, parseTokenRefreshFlags, and parseTokenExchangeFlags with an io.Reader parameter threaded from CLI() through RunCommand. The three non-stdin parsers accept the reader via _ io.Reader to keep Command.Configure uniform.

Tests drop the os.Pipe() + os.Stdin swap and pass strings.NewReader directly, removing the last shared-process-state hazard in the cmd package and unblocking t.Parallel() in the upcoming parallelism sweep.