### PR TITLE
refactor: extract readTokenFromStdin helper

### DIFF
--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -64,7 +64,6 @@ func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Conf
 		return nil, buf.String(), err
 	}
 
-	// populate custom args
 	if len(customArgs) > 0 {
 		if flowConf.CustomArgs == nil {
 			flowConf.CustomArgs = &httpclient.CustomArgs{}

--- a/cmd/command_runner.go
+++ b/cmd/command_runner.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
@@ -14,6 +15,17 @@ import (
 	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/oidc"
 )
+
+func readTokenFromStdin(r io.Reader, label string) (string, error) {
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", fmt.Errorf("no %s provided on stdin", label)
+	}
+	return scanner.Text(), nil
+}
 
 type CommandRunner interface {
 	Run(ctx context.Context) error

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"flag"
@@ -41,7 +40,6 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, std
 		return nil, buf.String(), err
 	}
 
-	// populate custom args
 	if len(customArgs) > 0 {
 		if flowConf.CustomArgs == nil {
 			flowConf.CustomArgs = &httpclient.CustomArgs{}
@@ -55,14 +53,11 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, std
 	}
 
 	if flowConf.Token == "-" {
-		scanner := bufio.NewScanner(stdin)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return nil, buf.String(), err
-			}
-			return nil, buf.String(), errors.New("no token provided on stdin")
+		token, err := readTokenFromStdin(stdin, "token")
+		if err != nil {
+			return nil, buf.String(), err
 		}
-		flowConf.Token = scanner.Text()
+		flowConf.Token = token
 	}
 
 	var invalidArgsChecks = []struct {

--- a/cmd/token_exchange_cfg.go
+++ b/cmd/token_exchange_cfg.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"flag"
@@ -46,14 +45,11 @@ func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config, 
 	}
 
 	if flowConf.SubjectToken == "-" {
-		scanner := bufio.NewScanner(stdin)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return nil, buf.String(), err
-			}
-			return nil, buf.String(), errors.New("no subject token provided on stdin")
+		token, err := readTokenFromStdin(stdin, "subject token")
+		if err != nil {
+			return nil, buf.String(), err
 		}
-		flowConf.SubjectToken = scanner.Text()
+		flowConf.SubjectToken = token
 	}
 
 	var invalidArgsChecks = []struct {

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"flag"
@@ -40,14 +39,11 @@ func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config, s
 	}
 
 	if flowConf.RefreshToken == "-" {
-		scanner := bufio.NewScanner(stdin)
-		if !scanner.Scan() {
-			if err := scanner.Err(); err != nil {
-				return nil, buf.String(), err
-			}
-			return nil, buf.String(), errors.New("no refresh token provided on stdin")
+		token, err := readTokenFromStdin(stdin, "refresh token")
+		if err != nil {
+			return nil, buf.String(), err
 		}
-		flowConf.RefreshToken = scanner.Text()
+		flowConf.RefreshToken = token
 	}
 
 	var invalidArgsChecks = []struct {


### PR DESCRIPTION
The three stdin-reading parsers (parseIntrospectFlags, parseTokenRefreshFlags, parseTokenExchangeFlags) shared an identical 9-line scanner block that only differed in the field name and error message. Extract readTokenFromStdin in command_runner.go and collapse each call site to five lines. The helper takes a token-kind label and formats the "no %s provided on stdin" error itself so the phrasing stays consistent.

Also drop the stray "// populate custom args" narration comment from parseAuthorizationCodeFlags -- its twin in parseIntrospectFlags was already removed as a side-effect of the refactor.