### PR TITLE
refactor: remove default logger and inject via config

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/log"
 )
 
@@ -20,7 +21,7 @@ const (
 func CLI(args []string, logOptions ...log.Option) int {
 	logger := log.New(logOptions...)
 
-	globalConf, flagSet, err := parseGlobalFlags("global flags", args)
+	globalConf, flagSet, verbose, err := parseGlobalFlags("global flags", args)
 	args = flagSet.Args()
 
 	flag.Usage = func() {
@@ -36,6 +37,13 @@ func CLI(args []string, logOptions ...log.Option) int {
 		logger.Errorln("See 'oidc-cli --help' for usage.")
 		return ExitError
 	}
+
+	logger.SetVerbose(verbose)
+	globalConf.Logger = logger
+	globalConf.Client = httpclient.NewClient(&httpclient.Config{
+		SkipTLSVerify: globalConf.SkipTLSVerify,
+		Logger:        logger,
+	})
 
 	// If no command is specified, print usage and exit
 	if len(args) < 1 {

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -14,13 +14,8 @@ func resetFlags() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 }
 
-func resetLogger() {
-	log.SetDefaultLogger(log.WithVerbose(false))
-}
-
 func TestCLI_HelpFlag(t *testing.T) {
 	resetFlags()
-	resetLogger()
 	var out bytes.Buffer
 	code := CLI([]string{"--help"}, log.WithOutput(&out, &out))
 	if code != ExitHelp {
@@ -36,7 +31,6 @@ func TestCLI_HelpFlag(t *testing.T) {
 
 func TestCLI_NoArgs(t *testing.T) {
 	resetFlags()
-	resetLogger()
 	var out bytes.Buffer
 	code := CLI([]string{}, log.WithOutput(&out, &out))
 	if code != ExitError {
@@ -49,7 +43,6 @@ func TestCLI_NoArgs(t *testing.T) {
 
 func TestCLI_UnknownCommand(t *testing.T) {
 	resetFlags()
-	resetLogger()
 	var out bytes.Buffer
 	code := CLI([]string{"unknowncmd"}, log.WithOutput(&out, &out))
 	if code != ExitError {
@@ -62,7 +55,6 @@ func TestCLI_UnknownCommand(t *testing.T) {
 
 func TestCLI_VersionCommand(t *testing.T) {
 	resetFlags()
-	resetLogger()
 	var out bytes.Buffer
 	code := CLI([]string{"version"}, log.WithOutput(&out, &out))
 	if code != ExitOK {

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"flag"
 
-	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, flags *flag.FlagSet, err error) {
-	oidcConf = &oidc.Config{}
+func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, flags *flag.FlagSet, verbose bool, err error) {
+	oidcConf = oidc.NewConfig()
 
 	flags = flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
@@ -21,23 +19,13 @@ func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, flags 
 	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret")
 
-	var skipTLSVerify bool
-	flags.BoolVar(&skipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
-
-	var verbose bool
+	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
 	flags.BoolVar(&verbose, "verbose", false, "enable verbose output")
 
 	err = flags.Parse(args)
 	if err != nil {
-		return nil, flags, err
+		return nil, flags, false, err
 	}
 
-	log.SetDefaultLogger(log.WithVerbose(verbose))
-
-	oidcConf.SkipTLSVerify = skipTLSVerify // temporary compatibility
-	oidcConf.Client = httpclient.NewClient(&httpclient.Config{
-		SkipTLSVerify: skipTLSVerify,
-	})
-
-	return oidcConf, flags, nil
+	return oidcConf, flags, verbose, nil
 }

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -12,90 +12,90 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 		name          string
 		args          []string
 		oidcConf      oidc.Config
+		wantVerbose   bool
 		remainingArgs []string
 	}{
 		{
-			"all flags",
-			[]string{
+			name: "all flags",
+			args: []string{
 				"--issuer", "https://example.com",
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
 				"--skip-tls-verify",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 			},
-			oidc.Config{
+			oidcConf: oidc.Config{
 				IssuerURL:         "https://example.com",
 				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
 				ClientID:          "client-id",
 				ClientSecret:      "client-secret",
 				SkipTLSVerify:     true,
 			},
-			[]string{},
+			remainingArgs: []string{},
 		},
 		{
-			"only issuer",
-			[]string{
+			name: "only issuer",
+			args: []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 			},
-			oidc.Config{
-				IssuerURL:         "https://example.com",
-				DiscoveryEndpoint: "",
-				ClientID:          "client-id",
-				ClientSecret:      "client-secret",
+			oidcConf: oidc.Config{
+				IssuerURL:    "https://example.com",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
 			},
-			[]string{},
+			remainingArgs: []string{},
 		},
 		{
-			"verbose flag",
-			[]string{
+			name: "verbose flag",
+			args: []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"--verbose",
 			},
-			oidc.Config{
-				IssuerURL:         "https://example.com",
-				DiscoveryEndpoint: "",
-				ClientID:          "client-id",
-				ClientSecret:      "client-secret",
+			oidcConf: oidc.Config{
+				IssuerURL:    "https://example.com",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
 			},
-			[]string{},
+			wantVerbose:   true,
+			remainingArgs: []string{},
 		},
 		{
-			"flags after non-flag argument",
-			[]string{
+			name: "flags after non-flag argument",
+			args: []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"non-flag-argument",
 				"--skip-tls-verify",
 			},
-			oidc.Config{
-				IssuerURL:         "https://example.com",
-				DiscoveryEndpoint: "",
-				ClientID:          "client-id",
-				ClientSecret:      "client-secret",
-				SkipTLSVerify:     false, // expecting default value as argument is not parsed
+			oidcConf: oidc.Config{
+				IssuerURL:    "https://example.com",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
 			},
-			[]string{"non-flag-argument", "--skip-tls-verify"},
+			remainingArgs: []string{"non-flag-argument", "--skip-tls-verify"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oidcConf, flagSet, err := parseGlobalFlags("global", tt.args)
+			oidcConf, flagSet, verbose, err := parseGlobalFlags("global", tt.args)
 			remainingArgs := flagSet.Args()
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
 
 			gotConf := *oidcConf
-			gotConf.Client = nil // Ignore client in comparison
-
+			gotConf.Logger = nil // Logger is set by NewConfig(), not by flag parsing
 			if !reflect.DeepEqual(gotConf, tt.oidcConf) {
 				t.Errorf("Config got %+v, want %+v", gotConf, tt.oidcConf)
+			}
+			if verbose != tt.wantVerbose {
+				t.Errorf("verbose got %v, want %v", verbose, tt.wantVerbose)
 			}
 			if !reflect.DeepEqual(remainingArgs, tt.remainingArgs) {
 				t.Errorf("remainingArgs got %v, want %v", remainingArgs, tt.remainingArgs)

--- a/httpclient/auth_flow_components.go
+++ b/httpclient/auth_flow_components.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"context"
 
+	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/webflow"
 )
 
@@ -41,9 +42,9 @@ type AuthFlowDependencies struct {
 }
 
 // NewAuthFlowDependencies creates a new set of dependencies with default implementations.
-func NewAuthFlowDependencies() *AuthFlowDependencies {
+func NewAuthFlowDependencies(logger *log.Logger) *AuthFlowDependencies {
 	return &AuthFlowDependencies{
-		ServerManager:     &DefaultCallbackServerManager{},
+		ServerManager:     &DefaultCallbackServerManager{logger: logger},
 		URLBuilder:        &DefaultAuthorizationURLBuilder{},
 		BrowserLauncher:   NewDefaultBrowserLauncher(),
 		ResponseValidator: &DefaultResponseValidator{},

--- a/httpclient/authorization_code.go
+++ b/httpclient/authorization_code.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-
-	"github.com/jentz/oidc-cli/log"
 )
 
 type AuthorizationCodeRequest struct {
@@ -114,12 +112,12 @@ func (c *Client) ExecuteAuthorizationCodeRequest(ctx context.Context, endpoint s
 	if err != nil {
 		return nil, err // Error already wrapped by URLBuilder
 	}
-	log.Printf("authorization request: %s\n", requestURL)
+	c.logger.Printf("authorization request: %s\n", requestURL)
 
 	// Open the URL in the browser
 	err = c.authDeps.BrowserLauncher.OpenURL(requestURL)
 	if err != nil {
-		log.Errorf("unable to open browser because %v, visit %s to continue\n", err, requestURL)
+		c.logger.Errorf("unable to open browser because %v, visit %s to continue\n", err, requestURL)
 	}
 
 	// Wait for the callback response

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/jentz/oidc-cli/log"
 )
 
 // Config holds HTTP client configuration.
@@ -18,6 +20,7 @@ type Config struct {
 	SkipTLSVerify bool              // Skip TLS verification for HTTP requests
 	Timeout       time.Duration     // Timeout for HTTP requests
 	Transport     http.RoundTripper // Custom HTTP transport, if any
+	Logger        *log.Logger       // Logger for client output; if nil, output is discarded
 }
 
 // SleepFunc is a function that sleeps for a duration, respecting context cancellation.
@@ -28,6 +31,7 @@ type Client struct {
 	client    *http.Client
 	authDeps  *AuthFlowDependencies // Optional dependencies for authorization flows
 	sleepFunc SleepFunc             // Optional; if nil, sleep() falls back to sleepWithContext
+	logger    *log.Logger
 }
 
 // Response represents an HTTP response with convenience methods
@@ -65,12 +69,18 @@ func NewClient(cfg *Config) *Client {
 		transport = httpTransport
 	}
 
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.Discard()
+	}
+
 	return &Client{
 		client: &http.Client{
 			Transport: transport,
 			Timeout:   cfg.Timeout,
 		},
-		authDeps: NewAuthFlowDependencies(), // Initialize with default dependencies
+		authDeps: NewAuthFlowDependencies(logger),
+		logger:   logger,
 	}
 }
 

--- a/httpclient/server_manager.go
+++ b/httpclient/server_manager.go
@@ -7,11 +7,14 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/webflow"
 )
 
 // DefaultCallbackServerManager implements CallbackServerManager using the existing server logic.
-type DefaultCallbackServerManager struct{}
+type DefaultCallbackServerManager struct {
+	logger *log.Logger
+}
 
 // Ensure DefaultCallbackServerManager implements the interface.
 var _ CallbackServerManager = (*DefaultCallbackServerManager)(nil)
@@ -32,7 +35,7 @@ func (m *DefaultCallbackServerManager) StartServer(ctx context.Context, callback
 		return nil, ctx.Err()
 	}
 
-	callbackServer, err := webflow.NewCallbackServer(callback)
+	callbackServer, err := webflow.NewCallbackServer(callback, m.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create callback server: %w", err)
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -13,6 +13,12 @@ type Logger struct {
 	stdOut  io.Writer
 }
 
+// Discard returns a logger that discards all output. Each call returns a
+// new instance so callers cannot mutate shared state.
+func Discard() *Logger {
+	return New(WithOutput(io.Discard, io.Discard))
+}
+
 type Option func(*Logger)
 
 // WithVerbose enables verbose logging.
@@ -57,6 +63,13 @@ func New(opts ...Option) *Logger {
 	}
 
 	return logger
+}
+
+// SetVerbose toggles verbose output on this logger. Intended for callers
+// that must construct the logger before knowing the desired verbosity
+// (e.g. when the flag is not yet parsed).
+func (l *Logger) SetVerbose(verbose bool) {
+	l.verbose = verbose
 }
 
 // Printf formats and writes a message to the error output (only in verbose mode).
@@ -105,51 +118,4 @@ func (l *Logger) Verboseln(args ...interface{}) {
 	if l.verbose {
 		_, _ = fmt.Fprintln(l.stdOut, args...)
 	}
-}
-
-var defaultLogger = New(WithVerbose(true), WithStderr(os.Stderr), WithStdout(os.Stdout))
-
-// SetDefaultLogger sets the default logger with the provided options.
-func SetDefaultLogger(opts ...Option) {
-	defaultLogger = New(opts...)
-}
-
-// Printf writes formatted output to the default logger's error output.
-func Printf(format string, a ...interface{}) {
-	defaultLogger.Printf(format, a...)
-}
-
-// Println writes a line to the default logger's error output.
-func Println(a ...interface{}) {
-	defaultLogger.Println(a...)
-}
-
-// Errorf writes a formatted error message to the default logger's error output.
-func Errorf(format string, a ...interface{}) {
-	defaultLogger.Errorf(format, a...)
-}
-
-// Errorln writes a line to the default logger's error output.
-func Errorln(a ...interface{}) {
-	defaultLogger.Errorln(a...)
-}
-
-// Outputf writes formatted output to the default logger's standard output.
-func Outputf(format string, a ...interface{}) {
-	defaultLogger.Outputf(format, a...)
-}
-
-// Outputln writes a line to the default logger's standard output.
-func Outputln(a ...interface{}) {
-	defaultLogger.Outputln(a...)
-}
-
-// Verbosef writes formatted output to the default logger's standard output.
-func Verbosef(format string, a ...interface{}) {
-	defaultLogger.Verbosef(format, a...)
-}
-
-// Verboseln writes a line to the default logger's standard output.
-func Verboseln(a ...interface{}) {
-	defaultLogger.Verboseln(a...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -266,33 +266,43 @@ func TestFunctionalOptions(t *testing.T) {
 	})
 }
 
-func TestPackageLevelFunctions(t *testing.T) {
-	// Save original default logger
-	originalDefault := defaultLogger
-	defer func() { defaultLogger = originalDefault }()
+func TestDiscard(t *testing.T) {
+	logger := Discard()
+	if logger == nil {
+		t.Fatal("Discard() returned nil")
+	}
 
-	// Create test logger as default
-	var errBuf, outBuf bytes.Buffer
-	defaultLogger = New(
-		WithVerbose(true),
-		WithOutput(&outBuf, &errBuf),
-	)
+	logger.Printf("should not panic")
+	logger.Errorf("should not panic")
+	logger.Outputf("should not panic")
+	logger.Verbosef("should not panic")
 
-	t.Run("package level Printf", func(t *testing.T) {
-		errBuf.Reset()
-		Printf("test %s", "message")
-		if got := errBuf.String(); got != "test message" {
-			t.Errorf("Printf = %q, want %q", got, "test message")
-		}
-	})
+	if Discard() == logger {
+		t.Error("Discard() should return a new instance each call")
+	}
+}
 
-	t.Run("package level Outputf", func(t *testing.T) {
-		outBuf.Reset()
-		Outputf("result %d", 42)
-		if got := outBuf.String(); got != "result 42" {
-			t.Errorf("Outputf = %q, want %q", got, "result 42")
-		}
-	})
+func TestSetVerbose(t *testing.T) {
+	var errBuf bytes.Buffer
+	logger := New(WithVerbose(false), WithStderr(&errBuf))
+
+	logger.Printf("hidden")
+	if errBuf.Len() != 0 {
+		t.Errorf("expected no output with verbose=false, got %q", errBuf.String())
+	}
+
+	logger.SetVerbose(true)
+	logger.Printf("visible")
+	if got := errBuf.String(); got != "visible" {
+		t.Errorf("expected %q after SetVerbose(true), got %q", "visible", got)
+	}
+
+	errBuf.Reset()
+	logger.SetVerbose(false)
+	logger.Printf("hidden again")
+	if errBuf.Len() != 0 {
+		t.Errorf("expected no output after SetVerbose(false), got %q", errBuf.String())
+	}
 }
 
 func TestComplexScenario(t *testing.T) {

--- a/oidc/authorization_code.go
+++ b/oidc/authorization_code.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type AuthorizationCodeFlow struct {
@@ -167,6 +166,6 @@ func (c *AuthorizationCodeFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format token response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/oidc/client_credentials.go
+++ b/oidc/client_credentials.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type ClientCredentialsFlow struct {
@@ -43,6 +42,6 @@ func (c *ClientCredentialsFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format token response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/oidc/device.go
+++ b/oidc/device.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type DeviceFlow struct {
@@ -85,20 +84,20 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 		return httpclient.WrapError(err, "device authorization")
 	}
 
-	// Print link to verification URI
+	logger := c.Config.Logger
 	if deviceAuthResp.VerificationURIComplete != "" {
 		verificationURI := deviceAuthResp.VerificationURIComplete
-		log.Printf("device verification uri: %s\n", verificationURI)
+		logger.Printf("device verification uri: %s\n", verificationURI)
 		err := httpclient.NewDefaultBrowserLauncher().OpenURL(verificationURI)
 		if err != nil {
-			log.Errorf("failed to open verification uri %s in the default browser: %v\n", verificationURI, err)
+			logger.Errorf("failed to open verification uri %s in the default browser: %v\n", verificationURI, err)
 		}
 	} else {
 		verificationURI := deviceAuthResp.VerificationURI
-		log.Printf("device verification uri: %s, verification code: %s\n", verificationURI, deviceAuthResp.UserCode)
+		logger.Printf("device verification uri: %s, verification code: %s\n", verificationURI, deviceAuthResp.UserCode)
 		err := httpclient.NewDefaultBrowserLauncher().OpenURL(verificationURI)
 		if err != nil {
-			log.Errorf("failed to open verification uri %s in the default browser: %v\n", verificationURI, err)
+			logger.Errorf("failed to open verification uri %s in the default browser: %v\n", verificationURI, err)
 		}
 	}
 
@@ -124,6 +123,6 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format token response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/oidc/introspect.go
+++ b/oidc/introspect.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type IntrospectFlow struct {
@@ -51,6 +50,6 @@ func (c *IntrospectFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format introspection response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/oidc/oidc_config.go
+++ b/oidc/oidc_config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
+	"github.com/jentz/oidc-cli/log"
 )
 
 type Config struct {
@@ -27,6 +28,15 @@ type Config struct {
 	DPoPPrivateKey                     any
 	DPoPPublicKey                      any
 	Client                             *httpclient.Client
+	Logger                             *log.Logger
+}
+
+// NewConfig returns a Config with sensible defaults. Logger is set to
+// log.Discard() so callers that don't need logging can skip setting it.
+func NewConfig() *Config {
+	return &Config{
+		Logger: log.Discard(),
+	}
 }
 
 func (c *Config) DiscoverEndpoints(ctx context.Context) error {

--- a/oidc/token_exchange.go
+++ b/oidc/token_exchange.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type TokenExchangeFlow struct {
@@ -99,6 +98,6 @@ func (c *TokenExchangeFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format token response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/oidc/token_refresh.go
+++ b/oidc/token_refresh.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
-	"github.com/jentz/oidc-cli/log"
 )
 
 type TokenRefreshFlow struct {
@@ -64,6 +63,6 @@ func (c *TokenRefreshFlow) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to format token response: %w", err)
 	}
-	log.Outputf("%s\n", string(prettyJSON))
+	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
 	return nil
 }

--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -27,6 +27,7 @@ type CallbackServer struct {
 	listen      func(network, addr string) (net.Listener, error)
 	successTmpl *template.Template
 	errorTmpl   *template.Template
+	logger      *log.Logger
 }
 
 type CallbackResponse struct {
@@ -36,7 +37,7 @@ type CallbackResponse struct {
 	ErrorDescription string
 }
 
-func NewCallbackServer(callbackURI string) (*CallbackServer, error) {
+func NewCallbackServer(callbackURI string, logger *log.Logger) (*CallbackServer, error) {
 	u, err := url.Parse(callbackURI)
 	if err != nil {
 		return nil, fmt.Errorf("invalid callback URI: %w", err)
@@ -52,6 +53,10 @@ func NewCallbackServer(callbackURI string) (*CallbackServer, error) {
 		return nil, fmt.Errorf("failed to parse error template: %w", err)
 	}
 
+	if logger == nil {
+		logger = log.Discard()
+	}
+
 	return &CallbackServer{
 		host:        u.Host,
 		path:        u.Path,
@@ -59,6 +64,7 @@ func NewCallbackServer(callbackURI string) (*CallbackServer, error) {
 		listen:      net.Listen,
 		successTmpl: successTmpl,
 		errorTmpl:   errorTmpl,
+		logger:      logger,
 	}, nil
 }
 
@@ -126,7 +132,7 @@ func (s *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := tmpl.Execute(w, resp); err != nil {
-		log.Errorf("failed to execute template: %v", err)
+		s.logger.Errorf("failed to execute template: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
@@ -136,6 +142,6 @@ func (s *CallbackServer) handleCallback(w http.ResponseWriter, r *http.Request) 
 	case s.response <- &resp:
 		// Successfully sent the response
 	default:
-		log.Errorf("callback response channel is full, dropping response")
+		s.logger.Errorf("callback response channel is full, dropping response")
 	}
 }

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -52,7 +52,7 @@ func (m *mockListener) Addr() net.Addr {
 
 func TestNewCallbackServer(t *testing.T) {
 	// Skip if template files are missing (real files needed for embed.FS)
-	s, err := NewCallbackServer("http://localhost:8080/callback")
+	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "failed to parse") {
 			t.Skipf("Skipping due to missing template files: %v", err)
@@ -74,7 +74,7 @@ func TestNewCallbackServer(t *testing.T) {
 }
 
 func TestCallbackServerStart(t *testing.T) {
-	s, err := NewCallbackServer("http://localhost:8080/callback")
+	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestCallbackServerStart(t *testing.T) {
 }
 
 func TestCallbackServerStartListenError(t *testing.T) {
-	s, err := NewCallbackServer("http://localhost:8080/callback")
+	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestCallbackServerStartListenError(t *testing.T) {
 }
 
 func TestCallbackServerWaitForCallback(t *testing.T) {
-	s, err := NewCallbackServer("http://localhost:8080/callback")
+	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
 	}
@@ -157,10 +157,6 @@ func TestCallbackServerWaitForCallback(t *testing.T) {
 }
 
 func TestCallbackServerHandleCallback(t *testing.T) {
-	// Set up logger to capture output
-	var logBuf bytes.Buffer
-	log.SetDefaultLogger(log.WithVerbose(true), log.WithStderr(&logBuf), log.WithStdout(&logBuf))
-
 	tests := []struct {
 		name           string
 		query          string
@@ -221,9 +217,10 @@ func TestCallbackServerHandleCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logBuf.Reset()
+			var logBuf bytes.Buffer
+			logger := log.New(log.WithVerbose(true), log.WithOutput(&logBuf, &logBuf))
 
-			s, err := NewCallbackServer("http://localhost:8080/callback")
+			s, err := NewCallbackServer("http://localhost:8080/callback", logger)
 			if err != nil {
 				t.Skipf("Skipping due to template parsing error: %v", err)
 			}


### PR DESCRIPTION
## Summary

- Delete `log.defaultLogger` and all package-level wrapper functions
- Thread `*log.Logger` through `httpclient.Config`, `oidc.Config`, `webflow.CallbackServer`, and `DefaultCallbackServerManager`
- Add `log.Discard()` for callers that don't need logging and `Logger.SetVerbose()` for post-parse verbosity toggling
- Introduce `oidc.NewConfig()` constructor that defaults Logger to `log.Discard()`

## Test plan

- [x] `go test ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] Tests for `log.Discard()` and `log.SetVerbose()`
- [x] `parseGlobalFlags` test verifies verbose return value