### PR TITLE
test: enable t.Parallel across all tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: go build -v -o oidc-cli cmd/**
 
       - name: Run tests
-        run: go test -v ./...
+        run: go test -race -count=1 ./...
 
       - name: Test GoReleaser
         uses: goreleaser/goreleaser-action@v7

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - perfsprint
     - revive
     - thelper
+    - paralleltest
     - tparallel
     - unconvert
     - unparam

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "\nUsage: make <target>\n"
 	@echo "Targets:"
 	@echo "  help     Show this help message"
-	@echo "  test     Run all Go tests (go test -v ./...)"
+	@echo "  test     Run all Go tests (go test -race -count=1 ./...)"
 	@echo "  build    Build the oidc-cli binary (go build -v -o $(BINARY))"
 	@echo "  lint     Run golangci-lint (uses .golangci.yaml config)"
 	@echo "  clean    Remove built binaries and test cache"
@@ -17,7 +17,7 @@ help:
 # Run all tests
 
 test:
-	go test ./...
+	go test -race -count=1 ./...
 
 # Build the binary
 
@@ -38,4 +38,4 @@ clean:
 # Run tests with coverage
 
 coverage:
-	go test -coverprofile=coverage.out -covermode=atomic ./...
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -252,6 +253,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -274,6 +276,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 }
 
 func TestParseAuthorizationCodeFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name string
 		args []string
@@ -322,6 +325,7 @@ func TestParseAuthorizationCodeFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -14,7 +14,7 @@ func resetFlags() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 }
 
-func TestCLI_HelpFlag(t *testing.T) {
+func TestCLI_HelpFlag(t *testing.T) { //nolint:paralleltest // mutates global flag.CommandLine
 	resetFlags()
 	var out bytes.Buffer
 	code := CLI([]string{"--help"}, log.WithOutput(&out, &out))
@@ -29,7 +29,7 @@ func TestCLI_HelpFlag(t *testing.T) {
 	}
 }
 
-func TestCLI_NoArgs(t *testing.T) {
+func TestCLI_NoArgs(t *testing.T) { //nolint:paralleltest // mutates global flag.CommandLine
 	resetFlags()
 	var out bytes.Buffer
 	code := CLI([]string{}, log.WithOutput(&out, &out))
@@ -41,7 +41,7 @@ func TestCLI_NoArgs(t *testing.T) {
 	}
 }
 
-func TestCLI_UnknownCommand(t *testing.T) {
+func TestCLI_UnknownCommand(t *testing.T) { //nolint:paralleltest // mutates global flag.CommandLine
 	resetFlags()
 	var out bytes.Buffer
 	code := CLI([]string{"unknowncmd"}, log.WithOutput(&out, &out))
@@ -53,7 +53,7 @@ func TestCLI_UnknownCommand(t *testing.T) {
 	}
 }
 
-func TestCLI_VersionCommand(t *testing.T) {
+func TestCLI_VersionCommand(t *testing.T) { //nolint:paralleltest // mutates global flag.CommandLine
 	resetFlags()
 	var out bytes.Buffer
 	code := CLI([]string{"version"}, log.WithOutput(&out, &out))

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseClientCredentialsFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -78,6 +79,7 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -100,6 +102,7 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 }
 
 func TestParseClientCredentialsFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name string
 		args []string
@@ -123,6 +126,7 @@ func TestParseClientCredentialsFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")

--- a/cmd/device_cfg_test.go
+++ b/cmd/device_cfg_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseDeviceFlags(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -139,6 +140,7 @@ func TestParseDeviceFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -161,6 +163,7 @@ func TestParseDeviceFlags(t *testing.T) {
 }
 
 func TestParseDeviceFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name string
 		args []string
@@ -197,6 +200,7 @@ func TestParseDeviceFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParseGlobalFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name          string
 		args          []string
@@ -83,6 +84,7 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			oidcConf, flagSet, verbose, err := parseGlobalFlags("global", tt.args)
 			remainingArgs := flagSet.Args()
 			if err != nil {

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseIntrospectFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -89,6 +90,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -111,6 +113,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 }
 
 func TestParseIntrospectFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name string
 		args []string
@@ -142,6 +145,7 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
@@ -154,6 +158,7 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 }
 
 func TestParseIntrospectFlagsStdin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		input         string
@@ -181,6 +186,7 @@ func TestParseIntrospectFlagsStdin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			args := []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -220,6 +226,7 @@ func TestParseIntrospectFlagsStdin(t *testing.T) {
 }
 
 func TestParseIntrospectFlagsStdinError(t *testing.T) {
+	t.Parallel()
 	expectedError := "no token provided on stdin"
 
 	args := []string{
@@ -239,6 +246,7 @@ func TestParseIntrospectFlagsStdinError(t *testing.T) {
 }
 
 func TestParseIntrospectFlagsCustomArgs(t *testing.T) {
+	t.Parallel()
 	testArgs := []string{
 		"--issuer", "https://example.com",
 		"--client-id", "client-id",

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestParseTokenExchangeFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -77,6 +78,7 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -99,6 +101,7 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 }
 
 func TestParseTokenExchangeFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name          string
 		args          []string
@@ -175,6 +178,7 @@ func TestParseTokenExchangeFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
@@ -190,6 +194,7 @@ func TestParseTokenExchangeFlagsError(t *testing.T) {
 }
 
 func TestParseTokenExchangeFlagsStdin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		input         string
@@ -217,6 +222,7 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			args := []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -257,6 +263,7 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 }
 
 func TestParseTokenExchangeFlagsStdinError(t *testing.T) {
+	t.Parallel()
 	expectedError := "no subject token provided on stdin"
 
 	args := []string{

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestParseTokenRefreshFlagsResult(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name     string
 		args     []string
@@ -89,6 +90,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
@@ -111,6 +113,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 }
 
 func TestParseTokenRefreshFlagsError(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name          string
 		args          []string
@@ -178,6 +181,7 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
 			if err == nil {
 				t.Errorf("err got nil, want error")
@@ -193,6 +197,7 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 }
 
 func TestParseTokenRefreshFlagsStdin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		input         string
@@ -220,6 +225,7 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			args := []string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -259,6 +265,7 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 }
 
 func TestParseTokenRefreshFlagsStdinError(t *testing.T) {
+	t.Parallel()
 	expectedError := "no refresh token provided on stdin"
 
 	args := []string{

--- a/crypto/dpop_test.go
+++ b/crypto/dpop_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestNewDPoPProofBuilder(t *testing.T) {
+	t.Parallel()
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKey := &privateKey.PublicKey
 
@@ -38,6 +39,7 @@ func TestNewDPoPProofBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dpopProofBuilder := NewDPoPProofBuilder().PrivateKey(tt.privateKey).PublicKey(tt.publicKey).Method(tt.method).URL(tt.url)
 			if dpopProofBuilder == nil {
 				t.Errorf("NewDPoPProofBuilder() = %v, want %v", dpopProofBuilder, "not nil")
@@ -59,6 +61,7 @@ func TestNewDPoPProofBuilder(t *testing.T) {
 }
 
 func TestNewDPoPProofBuilderError(t *testing.T) {
+	t.Parallel()
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKey := &privateKey.PublicKey
 
@@ -101,6 +104,7 @@ func TestNewDPoPProofBuilderError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			dpopProofBuilder := NewDPoPProofBuilder().PrivateKey(tt.privateKey).PublicKey(tt.publicKey).Method(tt.method).URL(tt.url)
 			if len(dpopProofBuilder.errs) < 1 {
 				t.Errorf("NewDPoPProofBuilder() = %v, want %v", dpopProofBuilder.errs, "not empty")
@@ -110,6 +114,7 @@ func TestNewDPoPProofBuilderError(t *testing.T) {
 }
 
 func TestParseKeys(t *testing.T) {
+	t.Parallel()
 	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKeyRSA := &privateKeyRSA.PublicKey
 
@@ -146,6 +151,7 @@ func TestParseKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			builder := &DPoPProofBuilder{
 				privateKey: tt.privateKey,
 				publicKey:  tt.publicKey,
@@ -162,6 +168,7 @@ func TestParseKeys(t *testing.T) {
 }
 
 func TestParseKeysError(t *testing.T) {
+	t.Parallel()
 	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKeyRSA := &privateKeyRSA.PublicKey
 
@@ -222,6 +229,7 @@ func TestParseKeysError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			builder := &DPoPProofBuilder{
 				privateKey: tt.privateKey,
 				publicKey:  tt.publicKey,
@@ -235,6 +243,7 @@ func TestParseKeysError(t *testing.T) {
 }
 
 func TestConstructJWT(t *testing.T) {
+	t.Parallel()
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKey := &privateKey.PublicKey
 
@@ -256,6 +265,7 @@ func TestConstructJWT(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.dpopProofBuilder.generateJTI()
 			if err != nil {
 				t.Errorf("generateJTI() error = %v, wantErr %v", err, nil)
@@ -296,6 +306,7 @@ func TestConstructJWT(t *testing.T) {
 }
 
 func TestSignJWT(t *testing.T) {
+	t.Parallel()
 	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKey := &privateKey.PublicKey
 
@@ -319,6 +330,7 @@ func TestSignJWT(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.dpopProofBuilder.generateJTI()
 			if err != nil {
 				t.Errorf("generateJTI() error = %v, wantErr %v", err, nil)
@@ -336,6 +348,7 @@ func TestSignJWT(t *testing.T) {
 }
 
 func TestEcdsaPublicKeyToJWK(t *testing.T) {
+	t.Parallel()
 	curves := []struct {
 		name      string
 		curve     elliptic.Curve
@@ -349,6 +362,7 @@ func TestEcdsaPublicKeyToJWK(t *testing.T) {
 
 	for _, c := range curves {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			privateKey, err := ecdsa.GenerateKey(c.curve, rand.Reader)
 			if err != nil {
 				t.Fatalf("GenerateKey(%s) error: %v", c.name, err)
@@ -408,6 +422,7 @@ func TestEcdsaPublicKeyToJWK(t *testing.T) {
 }
 
 func TestEcdsaAlgorithmString(t *testing.T) {
+	t.Parallel()
 	privateKey256, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	publicKey256 := &privateKey256.PublicKey
 
@@ -441,6 +456,7 @@ func TestEcdsaAlgorithmString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := ecdsaAlgorithmString(tt.key)
 			if got != tt.expected {
 				t.Errorf("ecdsaAlgorithmString() = %v, want %v", got, tt.expected)
@@ -450,6 +466,7 @@ func TestEcdsaAlgorithmString(t *testing.T) {
 }
 
 func TestRsaAlgorithmString(t *testing.T) {
+	t.Parallel()
 	privateKey256, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKey256 := &privateKey256.PublicKey
 
@@ -483,6 +500,7 @@ func TestRsaAlgorithmString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := rsaAlgorithmString(tt.key)
 			if got != tt.expected {
 				t.Errorf("rsaAlgorithmString() = %v, want %v", got, tt.expected)

--- a/crypto/pem_test.go
+++ b/crypto/pem_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestParsePublicKeyPEMBlock(t *testing.T) {
+	t.Parallel()
 	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
 	publicKeyRSA := &privateKeyRSA.PublicKey
 	x509RSA, _ := x509.MarshalPKIXPublicKey(publicKeyRSA)
@@ -44,6 +45,7 @@ func TestParsePublicKeyPEMBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := ParsePublicKeyPEMBlock(tt.block)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParsePublicKeyPEMBlock() error = %v, wantErr %v", err, tt.wantErr)
@@ -53,6 +55,7 @@ func TestParsePublicKeyPEMBlock(t *testing.T) {
 }
 
 func TestParsePrivateKeyPEMBlock(t *testing.T) {
+	t.Parallel()
 	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
 	x509RSAPKCS1 := x509.MarshalPKCS1PrivateKey(privateKeyRSA)
 	x509RSAPKCS8, _ := x509.MarshalPKCS8PrivateKey(privateKeyRSA)
@@ -89,6 +92,7 @@ func TestParsePrivateKeyPEMBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := ParsePrivateKeyPEMBlock(tt.block)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParsePrivateKeyPEMBlock() error = %v, wantErr %v", err, tt.wantErr)

--- a/crypto/pkce_test.go
+++ b/crypto/pkce_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestGeneratePKCECodeVerifier(t *testing.T) {
+	t.Parallel()
 	verifier, err := GeneratePKCECodeVerifier()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -22,6 +23,7 @@ func TestGeneratePKCECodeVerifier(t *testing.T) {
 }
 
 func TestGeneratePKCECodeChallenge(t *testing.T) {
+	t.Parallel()
 	verifier := "testverifier"
 	challenge := GeneratePKCECodeChallenge(verifier)
 	// SHA256 output is 32 bytes, base64url-encoded is 43 chars (no padding)

--- a/httpclient/authorization_code_integration_test.go
+++ b/httpclient/authorization_code_integration_test.go
@@ -73,6 +73,7 @@ func (m *MockResponseValidator) ValidateResponse(req *AuthorizationCodeRequest, 
 
 // TestExecuteAuthorizationCodeRequest_WithMocks covers the scenario of executing an authorization code request with mocked dependencies.
 func TestExecuteAuthorizationCodeRequest_WithMocks(t *testing.T) {
+	t.Parallel()
 	client := NewClient(nil)
 
 	// Create mock dependencies
@@ -162,6 +163,7 @@ func TestExecuteAuthorizationCodeRequest_WithMocks(t *testing.T) {
 // TestExecuteAuthorizationCodeRequest_ComponentIsolation demonstrates how individual
 // components can be tested in isolation.
 func TestExecuteAuthorizationCodeRequest_ComponentIsolation(t *testing.T) {
+	t.Parallel()
 	client := NewClient(nil)
 
 	// Test scenario: Server manager fails to start server

--- a/httpclient/authorization_code_test.go
+++ b/httpclient/authorization_code_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCreateAuthorizationCodeRequestValues(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		req        *AuthorizationCodeRequest
@@ -97,6 +98,7 @@ func TestCreateAuthorizationCodeRequestValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			values, err := CreateAuthorizationCodeRequestValues(tt.req)
 
 			if tt.wantErr {
@@ -127,6 +129,7 @@ func TestCreateAuthorizationCodeRequestValues(t *testing.T) {
 }
 
 func TestCreateAuthorizationCodeRequestURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		endpoint string
@@ -181,6 +184,7 @@ func TestCreateAuthorizationCodeRequestURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotURL, err := CreateAuthorizationCodeRequestURL(tt.endpoint, tt.values)
 
 			if tt.wantErr {
@@ -237,6 +241,7 @@ func TestCreateAuthorizationCodeRequestURL(t *testing.T) {
 }
 
 func TestExecuteAuthorizationCodeRequest_BasicValidation(t *testing.T) {
+	t.Parallel()
 	// Test basic parameter validation without actually executing the flow
 	client := NewClient(nil)
 	ctx := context.Background()
@@ -258,6 +263,7 @@ func TestExecuteAuthorizationCodeRequest_BasicValidation(t *testing.T) {
 }
 
 func TestStateValidationLogic(t *testing.T) {
+	t.Parallel()
 	// Test the state validation logic by simulating various callback scenarios
 	tests := []struct {
 		name             string
@@ -319,6 +325,7 @@ func TestStateValidationLogic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Simulate the state validation logic from ExecuteAuthorizationCodeRequest
 			req := &AuthorizationCodeRequest{
 				ClientID: "test-client",

--- a/httpclient/browser_launcher_test.go
+++ b/httpclient/browser_launcher_test.go
@@ -18,6 +18,7 @@ func (m *MockBrowser) Open(url string) error {
 }
 
 func TestDefaultBrowserLauncher_OpenURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		url        string
@@ -60,6 +61,7 @@ func TestDefaultBrowserLauncher_OpenURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockBrowser := &MockBrowser{openFunc: tt.mockOpen}
 			launcher := NewDefaultBrowserLauncherWithBrowser(mockBrowser)
 
@@ -83,11 +85,13 @@ func TestDefaultBrowserLauncher_OpenURL(t *testing.T) {
 	}
 }
 
-func TestDefaultBrowserLauncher_Interface(_ *testing.T) {
+func TestDefaultBrowserLauncher_Interface(t *testing.T) {
+	t.Parallel()
 	var _ BrowserLauncher = (*DefaultBrowserLauncher)(nil)
 }
 
 func TestNewDefaultBrowserLauncher(t *testing.T) {
+	t.Parallel()
 	launcher := NewDefaultBrowserLauncher()
 	if launcher == nil {
 		t.Error("NewDefaultBrowserLauncher() returned nil")
@@ -99,6 +103,7 @@ func TestNewDefaultBrowserLauncher(t *testing.T) {
 }
 
 func TestNewDefaultBrowserLauncherWithBrowser(t *testing.T) {
+	t.Parallel()
 	mockBrowser := &MockBrowser{}
 	launcher := NewDefaultBrowserLauncherWithBrowser(mockBrowser)
 

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -14,13 +14,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	// Since we can't directly check internal fields without exposing them,
-	// we'll test behavior instead using a mock server.
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("test response"))
-	}))
-	defer ts.Close()
-
+	t.Parallel()
 	tests := []struct {
 		name          string
 		cfg           *Config
@@ -53,6 +47,7 @@ func TestNewClient(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Create a test server that sleeps for the specified time
 			sleepServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				time.Sleep(tt.serverDelay)
@@ -77,13 +72,15 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestTLSSkipVerify(t *testing.T) {
+	t.Parallel()
 	// Create a server with a self-signed cert
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("secure response"))
 	}))
-	defer ts.Close()
+	t.Cleanup(ts.Close)
 
 	t.Run("Skips TLS verification when configured", func(t *testing.T) {
+		t.Parallel()
 		client := NewClient(&Config{SkipTLSVerify: true})
 		_, err := client.Get(context.Background(), ts.URL, nil)
 		if err != nil {
@@ -92,6 +89,7 @@ func TestTLSSkipVerify(t *testing.T) {
 	})
 
 	t.Run("Fails on invalid cert by default", func(t *testing.T) {
+		t.Parallel()
 		client := NewClient(nil) // Default config
 		_, err := client.Get(context.Background(), ts.URL, nil)
 		if err == nil {
@@ -101,6 +99,7 @@ func TestTLSSkipVerify(t *testing.T) {
 }
 
 func TestCustomTransport(t *testing.T) {
+	t.Parallel()
 	// Test that a custom is transport respected
 	customTransport := &http.Transport{
 		MaxIdleConns: 100,
@@ -128,6 +127,7 @@ func TestCustomTransport(t *testing.T) {
 }
 
 func TestPost(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected POST method, got %s", r.Method)
@@ -161,6 +161,7 @@ func TestPost(t *testing.T) {
 }
 
 func TestPostForm(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected POST method, got %s", r.Method)
@@ -203,6 +204,7 @@ func TestPostForm(t *testing.T) {
 }
 
 func TestPostJSON(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("Expected POST method, got %s", r.Method)
@@ -258,6 +260,7 @@ func TestPostJSON(t *testing.T) {
 }
 
 func TestPostJSON_MarshalError(t *testing.T) {
+	t.Parallel()
 	client := NewClient(nil)
 
 	// Use a function as data, which cannot be marshaled to JSON
@@ -270,6 +273,7 @@ func TestPostJSON_MarshalError(t *testing.T) {
 }
 
 func TestResponseMethods(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -314,6 +318,7 @@ func TestResponseMethods(t *testing.T) {
 }
 
 func TestResponseJSON_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("invalid json"))
@@ -334,6 +339,7 @@ func TestResponseJSON_InvalidJSON(t *testing.T) {
 }
 
 func TestResponseIsSuccess(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -349,6 +355,7 @@ func TestResponseIsSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
 				_, _ = w.Write([]byte("test"))
@@ -370,6 +377,7 @@ func TestResponseIsSuccess(t *testing.T) {
 }
 
 func TestDo_InvalidURL(t *testing.T) {
+	t.Parallel()
 	client := NewClient(nil)
 	_, err := client.Do(context.Background(), http.MethodGet, "://invalid-url", nil, nil)
 	if err == nil {
@@ -378,6 +386,7 @@ func TestDo_InvalidURL(t *testing.T) {
 }
 
 func TestDo_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(50 * time.Millisecond)
 		_, _ = w.Write([]byte("delayed response"))
@@ -398,6 +407,7 @@ func TestDo_ContextCanceled(t *testing.T) {
 
 // Test that verifies response body close error propagation works correctly
 func TestDo_ResponseBodyCloseError(t *testing.T) {
+	t.Parallel()
 	// Create a test server that returns a response with a body that fails to close
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/httpclient/device_authorization_test.go
+++ b/httpclient/device_authorization_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestExecuteDeviceAuthorizationRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		req        *DeviceAuthorizationRequest
@@ -83,6 +84,7 @@ func TestExecuteDeviceAuthorizationRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					t.Errorf("expected POST request, got %s", r.Method)
@@ -123,6 +125,7 @@ func TestExecuteDeviceAuthorizationRequest(t *testing.T) {
 }
 
 func TestParseDeviceAuthorizationResponse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -176,6 +179,7 @@ func TestParseDeviceAuthorizationResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			resp := &Response{
 				StatusCode: tt.statusCode,
 				Body:       []byte(tt.body),

--- a/httpclient/errors_test.go
+++ b/httpclient/errors_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestError_Error(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		err  *Error
@@ -40,6 +41,7 @@ func TestError_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.err.Error()
 			if got != tt.want {
 				t.Errorf("Error() = %q, want %q", got, tt.want)
@@ -49,6 +51,7 @@ func TestError_Error(t *testing.T) {
 }
 
 func TestWrapError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		err       error
@@ -83,6 +86,7 @@ func TestWrapError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := WrapError(tt.err, tt.operation)
 			if got.Error() != tt.want {
 				t.Errorf("WrapError() = %q, want %q", got.Error(), tt.want)

--- a/httpclient/oauth2_test.go
+++ b/httpclient/oauth2_test.go
@@ -3,6 +3,7 @@ package httpclient
 import "testing"
 
 func TestCustomArgs_Set(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		args    CustomArgs
@@ -45,6 +46,7 @@ func TestCustomArgs_Set(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := tt.args.Set(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CustomArgs.Set() error = %v, wantErr %v", err, tt.wantErr)
@@ -62,6 +64,7 @@ func TestCustomArgs_Set(t *testing.T) {
 }
 
 func TestAuthMethod_IsValid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		method AuthMethod
@@ -76,6 +79,7 @@ func TestAuthMethod_IsValid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.method.IsValid()
 			if got != tt.want {
 				t.Errorf("AuthMethod.IsValid() = %v, want %v", got, tt.want)
@@ -85,6 +89,7 @@ func TestAuthMethod_IsValid(t *testing.T) {
 }
 
 func TestAuthMethod_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		method AuthMethod
@@ -97,6 +102,7 @@ func TestAuthMethod_String(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := tt.method.String()
 			if got != tt.want {
 				t.Errorf("AuthMethod.String() = %q, want %q", got, tt.want)
@@ -106,6 +112,7 @@ func TestAuthMethod_String(t *testing.T) {
 }
 
 func TestAuthMethod_Set(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		value   string
@@ -139,6 +146,7 @@ func TestAuthMethod_Set(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var method AuthMethod
 			err := method.Set(tt.value)
 			if (err != nil) != tt.wantErr {

--- a/httpclient/pushed_authorization_request_test.go
+++ b/httpclient/pushed_authorization_request_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestExecutePushedAuthorizationRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		req        *PushedAuthorizationRequest
@@ -89,6 +90,7 @@ func TestExecutePushedAuthorizationRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					t.Errorf("Expected POST method, got %s", r.Method)
@@ -145,6 +147,7 @@ func TestExecutePushedAuthorizationRequest(t *testing.T) {
 }
 
 func TestParsePushedAuthorizationResponse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -219,6 +222,7 @@ func TestParsePushedAuthorizationResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			resp := &Response{
 				StatusCode: tt.statusCode,
 				Body:       []byte(tt.body),
@@ -259,6 +263,7 @@ func TestParsePushedAuthorizationResponse(t *testing.T) {
 }
 
 func TestPushedAuthorizationRequest_Integration(t *testing.T) {
+	t.Parallel()
 	// Integration test that combines ExecutePushedAuthorizationRequest and ParsePushedAuthorizationResponse
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()

--- a/httpclient/response_validator_test.go
+++ b/httpclient/response_validator_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestDefaultResponseValidator_ValidateResponse(t *testing.T) {
+	t.Parallel()
 	validator := &DefaultResponseValidator{}
 
 	tests := []struct {
@@ -139,6 +140,7 @@ func TestDefaultResponseValidator_ValidateResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := validator.ValidateResponse(tt.req, tt.resp)
 
 			if tt.wantErr {
@@ -173,6 +175,7 @@ func TestDefaultResponseValidator_ValidateResponse(t *testing.T) {
 	}
 }
 
-func TestDefaultResponseValidator_Interface(_ *testing.T) {
+func TestDefaultResponseValidator_Interface(t *testing.T) {
+	t.Parallel()
 	var _ ResponseValidator = (*DefaultResponseValidator)(nil)
 }

--- a/httpclient/server_manager_test.go
+++ b/httpclient/server_manager_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestDefaultCallbackServerManager_StartServer(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 
 	tests := []struct {
@@ -33,6 +34,7 @@ func TestDefaultCallbackServerManager_StartServer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 
@@ -60,6 +62,7 @@ func TestDefaultCallbackServerManager_StartServer(t *testing.T) {
 }
 
 func TestDefaultCallbackServerManager_StartServer_InvalidURL(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -79,6 +82,7 @@ func TestDefaultCallbackServerManager_StartServer_InvalidURL(t *testing.T) {
 }
 
 func TestDefaultCallbackServerManager_StartServer_ContextCanceled(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 
 	// Create a context that's already canceled
@@ -96,6 +100,7 @@ func TestDefaultCallbackServerManager_StartServer_ContextCanceled(t *testing.T) 
 }
 
 func TestDefaultCallbackServerManager_WaitForCallback(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 
 	tests := []struct {
@@ -114,6 +119,7 @@ func TestDefaultCallbackServerManager_WaitForCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
@@ -139,6 +145,7 @@ func TestDefaultCallbackServerManager_WaitForCallback(t *testing.T) {
 }
 
 func TestDefaultCallbackServerManager_WaitForCallback_Timeout(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 
 	// Create a server but don't send any callback
@@ -167,12 +174,14 @@ func TestDefaultCallbackServerManager_WaitForCallback_Timeout(t *testing.T) {
 	}
 }
 
-func TestDefaultCallbackServerManager_Interface(_ *testing.T) {
+func TestDefaultCallbackServerManager_Interface(t *testing.T) {
+	t.Parallel()
 	var _ CallbackServerManager = (*DefaultCallbackServerManager)(nil)
 }
 
 // Integration test to verify the full server lifecycle
 func TestDefaultCallbackServerManager_Integration(t *testing.T) {
+	t.Parallel()
 	manager := &DefaultCallbackServerManager{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestExecuteTokenRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		req        *TokenRequest
@@ -65,6 +66,7 @@ func TestExecuteTokenRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodPost {
 					t.Errorf("Expected POST method, got %s", r.Method)
@@ -106,6 +108,7 @@ func TestExecuteTokenRequest(t *testing.T) {
 }
 
 func TestExecutePollingTokenRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		intervals    []int
@@ -140,6 +143,7 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			attempts := 0
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if attempts >= len(tt.intervals) {
@@ -190,6 +194,7 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 }
 
 func TestExecutePollingTokenRequest_ContextCancellation(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 
 	attempts := 0
@@ -237,7 +242,9 @@ func TestExecutePollingTokenRequest_ContextCancellation(t *testing.T) {
 }
 
 func TestSleepWithContext(t *testing.T) {
+	t.Parallel()
 	t.Run("normal completion", func(t *testing.T) {
+		t.Parallel()
 		err := sleepWithContext(context.Background(), 50*time.Millisecond)
 		if err != nil {
 			t.Errorf("Expected nil error, got: %v", err)
@@ -245,6 +252,7 @@ func TestSleepWithContext(t *testing.T) {
 	})
 
 	t.Run("context cancelled during sleep", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		time.AfterFunc(50*time.Millisecond, cancel)
 
@@ -262,6 +270,7 @@ func TestSleepWithContext(t *testing.T) {
 	})
 
 	t.Run("already cancelled context", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
@@ -280,6 +289,7 @@ func TestSleepWithContext(t *testing.T) {
 }
 
 func TestCreateAuthCodeTokenRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		clientID     string
@@ -321,6 +331,7 @@ func TestCreateAuthCodeTokenRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := CreateAuthCodeTokenRequest(tt.clientID, tt.clientSecret, tt.authMethod, tt.code, tt.redirectURI, tt.codeVerifier)
 
 			// Check basic fields
@@ -354,6 +365,7 @@ func TestCreateAuthCodeTokenRequest(t *testing.T) {
 }
 
 func TestCreateRefreshTokenRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		clientID     string
@@ -390,6 +402,7 @@ func TestCreateRefreshTokenRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := CreateRefreshTokenRequest(tt.clientID, tt.clientSecret, tt.authMethod, tt.refreshToken, tt.scope)
 
 			// Check basic fields
@@ -414,6 +427,7 @@ func TestCreateRefreshTokenRequest(t *testing.T) {
 }
 
 func TestCreateClientCredentialsRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		clientID     string
@@ -444,6 +458,7 @@ func TestCreateClientCredentialsRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := CreateClientCredentialsRequest(tt.clientID, tt.clientSecret, tt.authMethod, tt.scope)
 
 			// Check basic fields
@@ -468,6 +483,7 @@ func TestCreateClientCredentialsRequest(t *testing.T) {
 }
 
 func TestCreateDeviceCodeTokenRequest(t *testing.T) {
+	t.Parallel()
 	req := CreateDeviceCodeTokenRequest("device-client", "device-secret", AuthMethodBasic, "device123", "test-code-verifier")
 
 	// Check basic fields
@@ -501,6 +517,7 @@ func TestCreateDeviceCodeTokenRequest(t *testing.T) {
 }
 
 func TestCreateTokenExchangeRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		clientID     string
@@ -560,6 +577,7 @@ func TestCreateTokenExchangeRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			req := CreateTokenExchangeRequest(tt.clientID, tt.clientSecret, tt.authMethod, tt.input)
 
 			// Check basic fields
@@ -595,6 +613,7 @@ func TestCreateTokenExchangeRequest(t *testing.T) {
 }
 
 func TestParseTokenResponse(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		statusCode int
@@ -639,6 +658,7 @@ func TestParseTokenResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			resp := &Response{
 				StatusCode: tt.statusCode,
 				Body:       []byte(tt.body),

--- a/httpclient/url_builder_test.go
+++ b/httpclient/url_builder_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestDefaultAuthorizationURLBuilder_BuildAuthorizationURL(t *testing.T) {
+	t.Parallel()
 	builder := &DefaultAuthorizationURLBuilder{}
 
 	tests := []struct {
@@ -76,6 +77,7 @@ func TestDefaultAuthorizationURLBuilder_BuildAuthorizationURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := builder.BuildAuthorizationURL(tt.endpoint, tt.req)
 
 			if tt.wantErr {
@@ -111,6 +113,7 @@ func TestDefaultAuthorizationURLBuilder_BuildAuthorizationURL(t *testing.T) {
 	}
 }
 
-func TestDefaultAuthorizationURLBuilder_Interface(_ *testing.T) {
+func TestDefaultAuthorizationURLBuilder_Interface(t *testing.T) {
+	t.Parallel()
 	var _ AuthorizationURLBuilder = (*DefaultAuthorizationURLBuilder)(nil)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -17,6 +17,7 @@ func setupTestLogger(verbose bool) (*Logger, *bytes.Buffer, *bytes.Buffer) {
 }
 
 func TestVerboseLogging(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		verbose bool
@@ -56,6 +57,7 @@ func TestVerboseLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			logger, errBuf, outBuf := setupTestLogger(tt.verbose)
 			tt.logFunc(logger)
 
@@ -70,6 +72,7 @@ func TestVerboseLogging(t *testing.T) {
 }
 
 func TestErrorLogging(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		verbose bool // should not affect error logging
@@ -104,6 +107,7 @@ func TestErrorLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			logger, errBuf, outBuf := setupTestLogger(tt.verbose)
 			tt.logFunc(logger)
 
@@ -118,6 +122,7 @@ func TestErrorLogging(t *testing.T) {
 }
 
 func TestOutputLogging(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		verbose bool // should not affect output logging
@@ -152,6 +157,7 @@ func TestOutputLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			logger, errBuf, outBuf := setupTestLogger(tt.verbose)
 			tt.logFunc(logger)
 
@@ -166,6 +172,7 @@ func TestOutputLogging(t *testing.T) {
 }
 
 func TestVerboseOutputLogging(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		verbose bool
@@ -200,6 +207,7 @@ func TestVerboseOutputLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			logger, errBuf, outBuf := setupTestLogger(tt.verbose)
 			tt.logFunc(logger)
 
@@ -214,7 +222,9 @@ func TestVerboseOutputLogging(t *testing.T) {
 }
 
 func TestFunctionalOptions(t *testing.T) {
+	t.Parallel()
 	t.Run("default logger", func(t *testing.T) {
+		t.Parallel()
 		logger := New()
 		if logger.verbose {
 			t.Error("default logger should not be verbose")
@@ -225,6 +235,7 @@ func TestFunctionalOptions(t *testing.T) {
 	})
 
 	t.Run("with verbose option", func(t *testing.T) {
+		t.Parallel()
 		logger := New(WithVerbose(true))
 		if !logger.verbose {
 			t.Error("logger should be verbose")
@@ -232,6 +243,7 @@ func TestFunctionalOptions(t *testing.T) {
 	})
 
 	t.Run("with custom writers", func(t *testing.T) {
+		t.Parallel()
 		var errBuf, outBuf bytes.Buffer
 		logger := New(WithOutput(&outBuf, &errBuf))
 
@@ -247,6 +259,7 @@ func TestFunctionalOptions(t *testing.T) {
 	})
 
 	t.Run("multiple options", func(t *testing.T) {
+		t.Parallel()
 		var errBuf, outBuf bytes.Buffer
 		logger := New(
 			WithVerbose(true),
@@ -267,6 +280,7 @@ func TestFunctionalOptions(t *testing.T) {
 }
 
 func TestDiscard(t *testing.T) {
+	t.Parallel()
 	logger := Discard()
 	if logger == nil {
 		t.Fatal("Discard() returned nil")
@@ -283,6 +297,7 @@ func TestDiscard(t *testing.T) {
 }
 
 func TestSetVerbose(t *testing.T) {
+	t.Parallel()
 	var errBuf bytes.Buffer
 	logger := New(WithVerbose(false), WithStderr(&errBuf))
 
@@ -306,6 +321,7 @@ func TestSetVerbose(t *testing.T) {
 }
 
 func TestComplexScenario(t *testing.T) {
+	t.Parallel()
 	// Test a realistic CLI scenario
 	logger, errBuf, outBuf := setupTestLogger(true)
 

--- a/oidc/discovery_test.go
+++ b/oidc/discovery_test.go
@@ -25,6 +25,7 @@ const defaultBody = `{
 }`
 
 func TestClientDiscover(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		config   *Config
@@ -96,6 +97,7 @@ func TestClientDiscover(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var capturedRequest *http.Request
 			transport := mockTransport(func(req *http.Request) (*http.Response, error) {
 				capturedRequest = req

--- a/webflow/browser_test.go
+++ b/webflow/browser_test.go
@@ -9,6 +9,7 @@ import (
 
 // TestSystemBrowserOpen tests the Open method for various platforms and scenarios.
 func TestSystemBrowserOpen(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name            string
 		url             string
@@ -63,6 +64,7 @@ func TestSystemBrowserOpen(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Set up RunCmd based on test case
 			var mockRunCmd func(prog string, args ...string) error
 			switch tt.name {
@@ -110,6 +112,7 @@ func TestSystemBrowserOpen(t *testing.T) {
 }
 
 func TestNewBrowser(t *testing.T) {
+	t.Parallel()
 	b := NewBrowser()
 	if b == nil {
 		t.Fatal("NewBrowser returned nil")
@@ -120,6 +123,7 @@ func TestNewBrowser(t *testing.T) {
 }
 
 func TestNewSystemBrowser(t *testing.T) {
+	t.Parallel()
 	b := NewSystemBrowser()
 	if b == nil {
 		t.Fatal("NewSystemBrowser returned nil")
@@ -133,6 +137,7 @@ func TestNewSystemBrowser(t *testing.T) {
 }
 
 func TestSystemBrowserDefaultRunCmd(t *testing.T) {
+	t.Parallel()
 	b := &SystemBrowser{
 		OpenBrowser: func(url string, runCmd func(string, ...string) error) error {
 			return runCmd("mythical-command", url)

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -51,6 +51,7 @@ func (m *mockListener) Addr() net.Addr {
 }
 
 func TestNewCallbackServer(t *testing.T) {
+	t.Parallel()
 	// Skip if template files are missing (real files needed for embed.FS)
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
@@ -74,6 +75,7 @@ func TestNewCallbackServer(t *testing.T) {
 }
 
 func TestCallbackServerStart(t *testing.T) {
+	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
@@ -112,6 +114,7 @@ func TestCallbackServerStart(t *testing.T) {
 }
 
 func TestCallbackServerStartListenError(t *testing.T) {
+	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
@@ -129,6 +132,7 @@ func TestCallbackServerStartListenError(t *testing.T) {
 }
 
 func TestCallbackServerWaitForCallback(t *testing.T) {
+	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
 	if err != nil {
 		t.Skipf("Skipping due to template parsing error: %v", err)
@@ -157,6 +161,7 @@ func TestCallbackServerWaitForCallback(t *testing.T) {
 }
 
 func TestCallbackServerHandleCallback(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		query          string
@@ -217,6 +222,7 @@ func TestCallbackServerHandleCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var logBuf bytes.Buffer
 			logger := log.New(log.WithVerbose(true), log.WithOutput(&logBuf, &logBuf))
 


### PR DESCRIPTION
Add t.Parallel() to every top-level test and subtest across all packages. Enable the paralleltest linter to prevent regression. Switch CI from go test -v to go test -race -count=1 to enforce race-free execution.

Tests that mutate global flag.CommandLine are excluded with nolint annotations. Replace defer ts.Close() with t.Cleanup where the tparallel linter requires it.