### PR TITLE
refactor: bundle parser args into ParseInput struct

### DIFF
--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/oidc"
@@ -21,8 +20,9 @@ func (c *CustomArgsFlag) Set(value string) error {
 	return nil
 }
 
-func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseAuthorizationCodeFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -59,7 +59,7 @@ func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Conf
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -254,7 +254,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseAuthorizationCodeFlags(ParseInput{Name: "authorization_code", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -326,7 +326,7 @@ func TestParseAuthorizationCodeFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseAuthorizationCodeFlags(ParseInput{Name: "authorization_code", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseClientCredentialsFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -29,7 +29,7 @@ func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Conf
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -80,7 +80,7 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseClientCredentialsFlags(ParseInput{Name: "client_credentials", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -127,7 +127,7 @@ func TestParseClientCredentialsFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseClientCredentialsFlags(ParseInput{Name: "client_credentials", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/command_runner.go
+++ b/cmd/command_runner.go
@@ -31,10 +31,17 @@ type CommandRunner interface {
 	Run(ctx context.Context) error
 }
 
+type ParseInput struct {
+	Name  string
+	Args  []string
+	Conf  *oidc.Config
+	Stdin io.Reader
+}
+
 type Command struct {
 	Name      string
 	Help      string
-	Configure func(name string, args []string, cfg *oidc.Config, stdin io.Reader) (config CommandRunner, output string, err error)
+	Configure func(in ParseInput) (config CommandRunner, output string, err error)
 }
 
 var commands = []Command{
@@ -70,7 +77,12 @@ func RunCommand(name string, args []string, globalConf *oidc.Config, logger *log
 		return ExitOK
 	}
 
-	command, output, err := cmd.Configure(name, args, globalConf, stdin)
+	command, output, err := cmd.Configure(ParseInput{
+		Name:  name,
+		Args:  args,
+		Conf:  globalConf,
+		Stdin: stdin,
+	})
 	if errors.Is(err, flag.ErrHelp) {
 		logger.Outputln(output)
 		return ExitHelp

--- a/cmd/device_cfg.go
+++ b/cmd/device_cfg.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseDeviceFlags(name string, args []string, oidcConf *oidc.Config, _ io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseDeviceFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -36,7 +36,7 @@ func parseDeviceFlags(name string, args []string, oidcConf *oidc.Config, _ io.Re
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}

--- a/cmd/device_cfg_test.go
+++ b/cmd/device_cfg_test.go
@@ -141,7 +141,7 @@ func TestParseDeviceFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseDeviceFlags(ParseInput{Name: "device", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -201,7 +201,7 @@ func TestParseDeviceFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseDeviceFlags("device", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseDeviceFlags(ParseInput{Name: "device", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -4,14 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseIntrospectFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -35,7 +35,7 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, std
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}
@@ -53,7 +53,7 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config, std
 	}
 
 	if flowConf.Token == "-" {
-		token, err := readTokenFromStdin(stdin, "token")
+		token, err := readTokenFromStdin(in.Stdin, "token")
 		if err != nil {
 			return nil, buf.String(), err
 		}

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -91,7 +91,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseIntrospectFlags(ParseInput{Name: "introspect", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -146,7 +146,7 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseIntrospectFlags(ParseInput{Name: "introspect", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -194,7 +194,7 @@ func TestParseIntrospectFlagsStdin(t *testing.T) {
 				"--token", "-", // This triggers stdin reading
 			}
 
-			runner, output, err := parseIntrospectFlags("introspect", args, &oidc.Config{}, strings.NewReader(tt.input))
+			runner, output, err := parseIntrospectFlags(ParseInput{Name: "introspect", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader(tt.input)})
 
 			if tt.expectError {
 				if err == nil {
@@ -236,7 +236,7 @@ func TestParseIntrospectFlagsStdinError(t *testing.T) {
 		"--token", "-", // This triggers stdin reading
 	}
 
-	_, _, err := parseIntrospectFlags("introspect", args, &oidc.Config{}, strings.NewReader(""))
+	_, _, err := parseIntrospectFlags(ParseInput{Name: "introspect", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 	if err == nil {
 		t.Error("expected error from empty stdin, got nil")
 	}
@@ -255,7 +255,7 @@ func TestParseIntrospectFlagsCustomArgs(t *testing.T) {
 		"--custom", "foo=bar",
 		"--custom", "baz=qux",
 	}
-	runner, output, err := parseIntrospectFlags("introspect", testArgs, &oidc.Config{}, strings.NewReader(""))
+	runner, output, err := parseIntrospectFlags(ParseInput{Name: "introspect", Args: testArgs, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 	if err != nil {
 		t.Fatalf("err got %v, want nil", err)
 	}

--- a/cmd/token_exchange_cfg.go
+++ b/cmd/token_exchange_cfg.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseTokenExchangeFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -39,13 +39,13 @@ func parseTokenExchangeFlags(name string, args []string, oidcConf *oidc.Config, 
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}
 
 	if flowConf.SubjectToken == "-" {
-		token, err := readTokenFromStdin(stdin, "subject token")
+		token, err := readTokenFromStdin(in.Stdin, "subject token")
 		if err != nil {
 			return nil, buf.String(), err
 		}

--- a/cmd/token_exchange_cfg_test.go
+++ b/cmd/token_exchange_cfg_test.go
@@ -79,7 +79,7 @@ func TestParseTokenExchangeFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseTokenExchangeFlags(ParseInput{Name: "token_exchange", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -179,7 +179,7 @@ func TestParseTokenExchangeFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseTokenExchangeFlags("token_exchange", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseTokenExchangeFlags(ParseInput{Name: "token_exchange", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -231,7 +231,7 @@ func TestParseTokenExchangeFlagsStdin(t *testing.T) {
 				"--subject-token-type", "subject-token-type",
 			}
 
-			runner, output, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{}, strings.NewReader(tt.input))
+			runner, output, err := parseTokenExchangeFlags(ParseInput{Name: "token_exchange", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader(tt.input)})
 
 			if tt.expectError {
 				if err == nil {
@@ -274,7 +274,7 @@ func TestParseTokenExchangeFlagsStdinError(t *testing.T) {
 		"--subject-token-type", "subject-token-type",
 	}
 
-	_, _, err := parseTokenExchangeFlags("token_exchange", args, &oidc.Config{}, strings.NewReader(""))
+	_, _, err := parseTokenExchangeFlags(ParseInput{Name: "token_exchange", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 	if err == nil {
 		t.Error("expected error from empty stdin, got nil")
 	}

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io"
 
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config, stdin io.Reader) (runner CommandRunner, output string, err error) {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+func parseTokenRefreshFlags(in ParseInput) (runner CommandRunner, output string, err error) {
+	oidcConf := in.Conf
+	flags := flag.NewFlagSet(in.Name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -33,13 +33,13 @@ func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config, s
 		FlowConfig: &flowConf,
 	}
 
-	err = flags.Parse(args)
+	err = flags.Parse(in.Args)
 	if err != nil {
 		return nil, buf.String(), err
 	}
 
 	if flowConf.RefreshToken == "-" {
-		token, err := readTokenFromStdin(stdin, "refresh token")
+		token, err := readTokenFromStdin(in.Stdin, "refresh token")
 		if err != nil {
 			return nil, buf.String(), err
 		}

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -91,7 +91,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
+			runner, output, err := parseTokenRefreshFlags(ParseInput{Name: "token_refresh", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -182,7 +182,7 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{}, strings.NewReader(""))
+			_, output, err := parseTokenRefreshFlags(ParseInput{Name: "token_refresh", Args: tt.args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}
@@ -233,7 +233,7 @@ func TestParseTokenRefreshFlagsStdin(t *testing.T) {
 				"--refresh-token", "-", // This triggers stdin reading
 			}
 
-			runner, output, err := parseTokenRefreshFlags("token_refresh", args, &oidc.Config{}, strings.NewReader(tt.input))
+			runner, output, err := parseTokenRefreshFlags(ParseInput{Name: "token_refresh", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader(tt.input)})
 
 			if tt.expectError {
 				if err == nil {
@@ -275,7 +275,7 @@ func TestParseTokenRefreshFlagsStdinError(t *testing.T) {
 		"--refresh-token", "-", // This triggers stdin reading
 	}
 
-	_, _, err := parseTokenRefreshFlags("token_refresh", args, &oidc.Config{}, strings.NewReader(""))
+	_, _, err := parseTokenRefreshFlags(ParseInput{Name: "token_refresh", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
 	if err == nil {
 		t.Error("expected error from empty stdin, got nil")
 	}


### PR DESCRIPTION
Replace four positional parameters (name, args, cfg, stdin) with a single ParseInput struct across all parse*Flags functions and the Command.Configure type. This improves readability and makes future parameter additions straightforward.