### PR TITLE
refactor: fully initialize Config in initGlobalConfig

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"os"
 
-	"github.com/jentz/oidc-cli/httpclient"
 	"github.com/jentz/oidc-cli/log"
 )
 
@@ -21,7 +20,7 @@ const (
 func CLI(args []string, logOptions ...log.Option) int {
 	logger := log.New(logOptions...)
 
-	globalConf, flagSet, verbose, err := parseGlobalFlags("global flags", args)
+	globalConf, flagSet, err := initGlobalConfig(args, logger)
 	args = flagSet.Args()
 
 	flag.Usage = func() {
@@ -37,13 +36,6 @@ func CLI(args []string, logOptions ...log.Option) int {
 		logger.Errorln("See 'oidc-cli --help' for usage.")
 		return ExitError
 	}
-
-	logger.SetVerbose(verbose)
-	globalConf.Logger = logger
-	globalConf.Client = httpclient.NewClient(&httpclient.Config{
-		SkipTLSVerify: globalConf.SkipTLSVerify,
-		Logger:        logger,
-	})
 
 	// If no command is specified, print usage and exit
 	if len(args) < 1 {

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"flag"
 
+	"github.com/jentz/oidc-cli/httpclient"
+	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/oidc"
 )
 
-func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, flags *flag.FlagSet, verbose bool, err error) {
+func initGlobalConfig(args []string, logger *log.Logger) (oidcConf *oidc.Config, flags *flag.FlagSet, err error) {
 	oidcConf = oidc.NewConfig()
 
-	flags = flag.NewFlagSet(name, flag.ContinueOnError)
+	var verbose bool
+
+	flags = flag.NewFlagSet("global flags", flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
@@ -24,8 +28,15 @@ func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, flags 
 
 	err = flags.Parse(args)
 	if err != nil {
-		return nil, flags, false, err
+		return nil, flags, err
 	}
 
-	return oidcConf, flags, verbose, nil
+	logger.SetVerbose(verbose)
+	oidcConf.Logger = logger
+	oidcConf.Client = httpclient.NewClient(&httpclient.Config{
+		SkipTLSVerify: oidcConf.SkipTLSVerify,
+		Logger:        logger,
+	})
+
+	return oidcConf, flags, nil
 }

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/oidc"
 )
 
@@ -13,7 +14,6 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 		name          string
 		args          []string
 		oidcConf      oidc.Config
-		wantVerbose   bool
 		remainingArgs []string
 	}{
 		{
@@ -61,7 +61,6 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 				ClientID:     "client-id",
 				ClientSecret: "client-secret",
 			},
-			wantVerbose:   true,
 			remainingArgs: []string{},
 		},
 		{
@@ -85,19 +84,25 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			oidcConf, flagSet, verbose, err := parseGlobalFlags("global", tt.args)
+			logger := log.Discard()
+			oidcConf, flagSet, err := initGlobalConfig(tt.args, logger)
 			remainingArgs := flagSet.Args()
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
 
+			if oidcConf.Logger != logger {
+				t.Error("expected Logger to be the injected instance")
+			}
+			if oidcConf.Client == nil {
+				t.Error("expected Client to be set")
+			}
+
 			gotConf := *oidcConf
-			gotConf.Logger = nil // Logger is set by NewConfig(), not by flag parsing
+			gotConf.Logger = nil
+			gotConf.Client = nil
 			if !reflect.DeepEqual(gotConf, tt.oidcConf) {
 				t.Errorf("Config got %+v, want %+v", gotConf, tt.oidcConf)
-			}
-			if verbose != tt.wantVerbose {
-				t.Errorf("verbose got %v, want %v", verbose, tt.wantVerbose)
 			}
 			if !reflect.DeepEqual(remainingArgs, tt.remainingArgs) {
 				t.Errorf("remainingArgs got %v, want %v", remainingArgs, tt.remainingArgs)


### PR DESCRIPTION
Move logger and HTTP client wiring from CLI() into the renamed initGlobalConfig (formerly parseGlobalFlags) so the returned oidc.Config is fully initialized with the correct parameters.

This eliminates the partially-built Config state that could cause nil-pointer panics if the oidc package is used directly without manually setting Config.Client.