### PR TITLE
fix: correct token request with dpop for device flow

### DIFF
--- a/httpclient/device_authorization.go
+++ b/httpclient/device_authorization.go
@@ -24,11 +24,7 @@ type DeviceAuthorizationResponse struct {
 }
 
 // ExecuteDeviceAuthorizationRequest sends a device authorization request to the specified endpoint
-func (c *Client) ExecuteDeviceAuthorizationRequest(ctx context.Context, endpoint string, req *DeviceAuthorizationRequest, headers map[string]string) (*Response, error) {
-	if headers == nil {
-		headers = make(map[string]string)
-	}
-
+func (c *Client) ExecuteDeviceAuthorizationRequest(ctx context.Context, endpoint string, req *DeviceAuthorizationRequest) (*Response, error) {
 	params := url.Values{}
 	params.Set("client_id", req.ClientID)
 	if req.Scope != "" {
@@ -42,7 +38,7 @@ func (c *Client) ExecuteDeviceAuthorizationRequest(ctx context.Context, endpoint
 	}
 
 	// Execute the request
-	return c.PostForm(ctx, endpoint, params, headers)
+	return c.PostForm(ctx, endpoint, params, nil)
 }
 
 // ParseDeviceAuthorizationResponse parses the device authorization response into a map

--- a/httpclient/device_authorization_test.go
+++ b/httpclient/device_authorization_test.go
@@ -111,7 +111,7 @@ func TestExecuteDeviceAuthorizationRequest(t *testing.T) {
 			defer ts.Close()
 
 			client := NewClient(nil)
-			resp, err := client.ExecuteDeviceAuthorizationRequest(context.Background(), ts.URL, tt.req, nil)
+			resp, err := client.ExecuteDeviceAuthorizationRequest(context.Background(), ts.URL, tt.req)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -23,6 +23,10 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 	}
 }
 
+// DPoPProofFunc generates a DPoP proof for the given HTTP method and URL.
+// It is called once per request, ensuring each token request carries a fresh proof.
+type DPoPProofFunc func(method, url string) (string, error)
+
 // TokenRequest represents an OAuth2 token request
 type TokenRequest struct {
 	GrantType    string
@@ -30,6 +34,7 @@ type TokenRequest struct {
 	ClientSecret string
 	AuthMethod   AuthMethod
 	Params       url.Values
+	DPoP         DPoPProofFunc
 }
 
 // TokenExchangeInput is used to construct the parameters of a token exchange request
@@ -46,14 +51,12 @@ type TokenExchangeInput struct {
 }
 
 // ExecuteTokenRequest sends a token request to the specified endpoint
-func (c *Client) ExecuteTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, headers map[string]string) (*Response, error) {
+func (c *Client) ExecuteTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest) (*Response, error) {
 	if req.Params == nil {
 		req.Params = url.Values{}
 	}
 
-	if headers == nil {
-		headers = make(map[string]string)
-	}
+	headers := make(map[string]string)
 
 	// Set grant type
 	req.Params.Set("grant_type", req.GrantType)
@@ -75,18 +78,27 @@ func (c *Client) ExecuteTokenRequest(ctx context.Context, tokenEndpoint string, 
 		req.Params.Set("client_id", req.ClientID)
 	}
 
+	// Generate and attach a fresh DPoP proof if configured
+	if req.DPoP != nil {
+		proof, err := req.DPoP("POST", tokenEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate DPoP proof: %w", err)
+		}
+		headers["DPoP"] = proof
+	}
+
 	// Execute the request
 	return c.PostForm(ctx, tokenEndpoint, req.Params, headers)
 }
 
 // ExecutePollingTokenRequest sends a token request to the specified endpoint, polling at the specified interval until a successful response is received
-func (c *Client) ExecutePollingTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, interval int, headers map[string]string) (*Response, error) {
+func (c *Client) ExecutePollingTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, interval int) (*Response, error) {
 	if interval <= 0 {
 		interval = 5 // Default polling interval in seconds
 	}
 
 	for {
-		resp, err := c.ExecuteTokenRequest(ctx, tokenEndpoint, req, headers)
+		resp, err := c.ExecuteTokenRequest(ctx, tokenEndpoint, req)
 		if err != nil {
 			return nil, err
 		}

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -80,13 +80,13 @@ func (c *Client) ExecuteTokenRequest(ctx context.Context, tokenEndpoint string, 
 }
 
 // ExecutePollingTokenRequest sends a token request to the specified endpoint, polling at the specified interval until a successful response is received
-func (c *Client) ExecutePollingTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, interval int) (*Response, error) {
+func (c *Client) ExecutePollingTokenRequest(ctx context.Context, tokenEndpoint string, req *TokenRequest, interval int, headers map[string]string) (*Response, error) {
 	if interval <= 0 {
 		interval = 5 // Default polling interval in seconds
 	}
 
 	for {
-		resp, err := c.ExecuteTokenRequest(ctx, tokenEndpoint, req, nil)
+		resp, err := c.ExecuteTokenRequest(ctx, tokenEndpoint, req, headers)
 		if err != nil {
 			return nil, err
 		}

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -3,6 +3,7 @@ package httpclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -107,6 +108,89 @@ func TestExecuteTokenRequest(t *testing.T) {
 	}
 }
 
+func TestExecuteTokenRequest_DPoPFunctionCalledWithMethodAndURL(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotURL string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader := r.Header.Get("DPoP")
+		if gotHeader != "proof-123" {
+			t.Errorf("got DPoP header %q, want %q", gotHeader, "proof-123")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token123","token_type":"Bearer"}`))
+	}))
+	defer ts.Close()
+
+	client := NewClient(nil)
+	req := &TokenRequest{
+		GrantType:    "client_credentials",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		AuthMethod:   AuthMethodPost,
+		DPoP: func(method, url string) (string, error) {
+			gotMethod = method
+			gotURL = url
+			return "proof-123", nil
+		},
+	}
+
+	resp, err := client.ExecuteTokenRequest(context.Background(), ts.URL, req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !resp.IsSuccess() {
+		t.Fatalf("Expected successful response, got status %d", resp.StatusCode)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("DPoP func method = %q, want %q", gotMethod, http.MethodPost)
+	}
+	if gotURL != ts.URL {
+		t.Errorf("DPoP func url = %q, want %q", gotURL, ts.URL)
+	}
+}
+
+func TestExecuteTokenRequest_DPoPGenerationError(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token123","token_type":"Bearer"}`))
+	}))
+	defer ts.Close()
+
+	client := NewClient(nil)
+	req := &TokenRequest{
+		GrantType:  "client_credentials",
+		ClientID:   "test-client",
+		AuthMethod: AuthMethodPost,
+		DPoP: func(_, _ string) (string, error) {
+			return "", errors.New("dpop generation failure")
+		},
+	}
+
+	resp, err := client.ExecuteTokenRequest(context.Background(), ts.URL, req)
+	if resp != nil {
+		t.Error("Expected nil response when DPoP generation fails")
+	}
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to generate DPoP proof") {
+		t.Errorf("Expected wrapped DPoP generation error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "dpop generation failure") {
+		t.Errorf("Expected original DPoP error message, got: %v", err)
+	}
+	if requests != 0 {
+		t.Errorf("Expected no HTTP requests when DPoP generation fails, got %d", requests)
+	}
+}
+
 func TestExecutePollingTokenRequest(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -190,6 +274,62 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 				t.Errorf("Expected %d attempts, got %d", tt.wantAttempts, attempts)
 			}
 		})
+	}
+}
+
+func TestExecutePollingTokenRequest_DPoPFreshPerAttempt(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	seenDPoP := make([]string, 0, 3)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenDPoP = append(seenDPoP, r.Header.Get("DPoP"))
+
+		if attempts < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"token123","token_type":"Bearer"}`))
+		}
+		attempts++
+	}))
+	defer ts.Close()
+
+	client := NewClient(nil)
+	client.SetSleepFunc(func(ctx context.Context, _ time.Duration) error {
+		return sleepWithContext(ctx, 1*time.Millisecond)
+	})
+
+	proofCounter := 0
+	req := &TokenRequest{
+		GrantType:    "urn:ietf:params:oauth:grant-type:device_code",
+		ClientID:     "device-client",
+		ClientSecret: "device-secret",
+		AuthMethod:   AuthMethodBasic,
+		Params:       url.Values{"device_code": []string{"device123"}},
+		DPoP: func(_, _ string) (string, error) {
+			proofCounter++
+			return fmt.Sprintf("proof-%d", proofCounter), nil
+		},
+	}
+
+	resp, err := client.ExecutePollingTokenRequest(context.Background(), ts.URL, req, 1)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !resp.IsSuccess() {
+		t.Fatalf("Expected successful response, got status %d", resp.StatusCode)
+	}
+
+	if len(seenDPoP) != 3 {
+		t.Fatalf("Expected 3 DPoP headers (one per attempt), got %d", len(seenDPoP))
+	}
+	for i, got := range seenDPoP {
+		want := fmt.Sprintf("proof-%d", i+1)
+		if got != want {
+			t.Errorf("Attempt %d DPoP header = %q, want %q", i+1, got, want)
+		}
 	}
 }
 

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -176,7 +176,7 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 			if len(tt.intervals) > 0 {
 				testInterval = tt.intervals[0]
 			}
-			resp, err := client.ExecutePollingTokenRequest(context.Background(), ts.URL, req, testInterval)
+			resp, err := client.ExecutePollingTokenRequest(context.Background(), ts.URL, req, testInterval, nil)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -221,7 +221,7 @@ func TestExecutePollingTokenRequest_ContextCancellation(t *testing.T) {
 	time.AfterFunc(100*time.Millisecond, cancel)
 
 	start := time.Now()
-	resp, err := client.ExecutePollingTokenRequest(ctx, ts.URL, req, 10)
+	resp, err := client.ExecutePollingTokenRequest(ctx, ts.URL, req, 10, nil)
 	elapsed := time.Since(start)
 
 	if resp != nil {

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -95,7 +95,7 @@ func TestExecuteTokenRequest(t *testing.T) {
 			defer ts.Close()
 
 			client := NewClient(nil)
-			resp, err := client.ExecuteTokenRequest(context.Background(), ts.URL, tt.req, nil)
+			resp, err := client.ExecuteTokenRequest(context.Background(), ts.URL, tt.req)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -176,7 +176,7 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 			if len(tt.intervals) > 0 {
 				testInterval = tt.intervals[0]
 			}
-			resp, err := client.ExecutePollingTokenRequest(context.Background(), ts.URL, req, testInterval, nil)
+			resp, err := client.ExecutePollingTokenRequest(context.Background(), ts.URL, req, testInterval)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -221,7 +221,7 @@ func TestExecutePollingTokenRequest_ContextCancellation(t *testing.T) {
 	time.AfterFunc(100*time.Millisecond, cancel)
 
 	start := time.Now()
-	resp, err := client.ExecutePollingTokenRequest(ctx, ts.URL, req, 10, nil)
+	resp, err := client.ExecutePollingTokenRequest(ctx, ts.URL, req, 10)
 	elapsed := time.Since(start)
 
 	if resp != nil {

--- a/oidc/authorization_code.go
+++ b/oidc/authorization_code.go
@@ -97,24 +97,7 @@ func (c *AuthorizationCodeFlow) executeAuthCodeRequest(ctx context.Context, req 
 	return resp, nil
 }
 
-func (c *AuthorizationCodeFlow) setupDPoPHeaders() (map[string]string, error) {
-	headers := make(map[string]string)
-	if c.FlowConfig.DPoP {
-		dpopProof, err := crypto.NewDPoPProof(
-			c.Config.DPoPPublicKey,
-			c.Config.DPoPPrivateKey,
-			"POST",
-			c.Config.TokenEndpoint,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create DPoP proof: %w", err)
-		}
-		headers["DPoP"] = dpopProof.String()
-	}
-	return headers, nil
-}
-
-func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, codeVerifier string, headers map[string]string) (map[string]interface{}, error) {
+func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, codeVerifier string, dpop httpclient.DPoPProofFunc) (map[string]interface{}, error) {
 	tokenRequest := httpclient.CreateAuthCodeTokenRequest(
 		c.Config.ClientID,
 		c.Config.ClientSecret,
@@ -123,7 +106,8 @@ func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, c
 		c.FlowConfig.CallbackURI,
 		codeVerifier,
 	)
-	resp, err := c.Config.Client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, tokenRequest, headers)
+	tokenRequest.DPoP = dpop
+	resp, err := c.Config.Client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, tokenRequest)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
@@ -151,12 +135,18 @@ func (c *AuthorizationCodeFlow) Run(ctx context.Context) error {
 		return err
 	}
 	// Handle DPoP
-	headers, err := c.setupDPoPHeaders()
-	if err != nil {
-		return err
+	var dpopFunc httpclient.DPoPProofFunc
+	if c.FlowConfig.DPoP {
+		dpopFunc = func(method, url string) (string, error) {
+			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
+			if err != nil {
+				return "", err
+			}
+			return proof.String(), nil
+		}
 	}
 	// Exchange authorization code for access token
-	tokenData, err := c.executeTokenRequest(ctx, authResp.Code, codeVerifier, headers)
+	tokenData, err := c.executeTokenRequest(ctx, authResp.Code, codeVerifier, dpopFunc)
 	if err != nil {
 		return err
 	}

--- a/oidc/client_credentials.go
+++ b/oidc/client_credentials.go
@@ -27,7 +27,7 @@ func (c *ClientCredentialsFlow) Run(ctx context.Context) error {
 		c.FlowConfig.Scopes,
 	)
 
-	resp, err := client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, req, nil /* no custom headers */)
+	resp, err := client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, req)
 	if err != nil {
 		return fmt.Errorf("token request failed: %w", err)
 	}

--- a/oidc/device.go
+++ b/oidc/device.go
@@ -68,13 +68,7 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 		req.CodeChallenge = crypto.GeneratePKCECodeChallenge(codeVerifier)
 	}
 
-	// Handle DPoP
-	headers, err := c.setupDPoPHeaders()
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.ExecuteDeviceAuthorizationRequest(ctx, c.Config.DeviceAuthorizationEndpoint, req, headers)
+	resp, err := client.ExecuteDeviceAuthorizationRequest(ctx, c.Config.DeviceAuthorizationEndpoint, req)
 	if err != nil {
 		return fmt.Errorf("device authorization request failed: %w", err)
 	}
@@ -109,7 +103,14 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 		deviceAuthResp.DeviceCode,
 		codeVerifier,
 	)
-	tokenResp, err := client.ExecutePollingTokenRequest(ctx, c.Config.TokenEndpoint, tokenReq, deviceAuthResp.Interval)
+
+	// Handle DPoP
+	headers, err := c.setupDPoPHeaders()
+	if err != nil {
+		return err
+	}
+
+	tokenResp, err := client.ExecutePollingTokenRequest(ctx, c.Config.TokenEndpoint, tokenReq, deviceAuthResp.Interval, headers)
 	if err != nil {
 		return fmt.Errorf("polling token request failed: %w", err)
 	}

--- a/oidc/device.go
+++ b/oidc/device.go
@@ -34,23 +34,6 @@ func (c *DeviceFlow) setupPKCE() (string, error) {
 	return codeVerifier, nil
 }
 
-func (c *DeviceFlow) setupDPoPHeaders() (map[string]string, error) {
-	headers := make(map[string]string)
-	if c.FlowConfig.DPoP {
-		dpopProof, err := crypto.NewDPoPProof(
-			c.Config.DPoPPublicKey,
-			c.Config.DPoPPrivateKey,
-			"POST",
-			c.Config.TokenEndpoint,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create DPoP proof: %w", err)
-		}
-		headers["DPoP"] = dpopProof.String()
-	}
-	return headers, nil
-}
-
 func (c *DeviceFlow) Run(ctx context.Context) error {
 	client := c.Config.Client
 	codeVerifier, err := c.setupPKCE()
@@ -104,13 +87,17 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 		codeVerifier,
 	)
 
-	// Handle DPoP
-	headers, err := c.setupDPoPHeaders()
-	if err != nil {
-		return err
+	if c.FlowConfig.DPoP {
+		tokenReq.DPoP = func(method, url string) (string, error) {
+			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
+			if err != nil {
+				return "", err
+			}
+			return proof.String(), nil
+		}
 	}
 
-	tokenResp, err := client.ExecutePollingTokenRequest(ctx, c.Config.TokenEndpoint, tokenReq, deviceAuthResp.Interval, headers)
+	tokenResp, err := client.ExecutePollingTokenRequest(ctx, c.Config.TokenEndpoint, tokenReq, deviceAuthResp.Interval)
 	if err != nil {
 		return fmt.Errorf("polling token request failed: %w", err)
 	}

--- a/oidc/token_exchange.go
+++ b/oidc/token_exchange.go
@@ -47,8 +47,8 @@ func (c *TokenExchangeFlow) createTokenRequest() *httpclient.TokenRequest {
 	return req
 }
 
-func (c *TokenExchangeFlow) executeTokenRequest(ctx context.Context, tokenRequest *httpclient.TokenRequest, headers map[string]string) (map[string]any, error) {
-	resp, err := c.Config.Client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, tokenRequest, headers)
+func (c *TokenExchangeFlow) executeTokenRequest(ctx context.Context, tokenRequest *httpclient.TokenRequest) (map[string]any, error) {
+	resp, err := c.Config.Client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, tokenRequest)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
@@ -61,34 +61,22 @@ func (c *TokenExchangeFlow) executeTokenRequest(ctx context.Context, tokenReques
 	return tokenData, nil
 }
 
-func (c *TokenExchangeFlow) setupDPoPHeaders() (map[string]string, error) {
-	headers := make(map[string]string)
-	if c.FlowConfig.DPoP {
-		dpopProof, err := crypto.NewDPoPProof(
-			c.Config.DPoPPublicKey,
-			c.Config.DPoPPrivateKey,
-			"POST",
-			c.Config.TokenEndpoint,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create DPoP proof: %w", err)
-		}
-		headers["DPoP"] = dpopProof.String()
-	}
-	return headers, nil
-}
-
 func (c *TokenExchangeFlow) Run(ctx context.Context) error {
 	req := c.createTokenRequest()
 
 	// Handle DPoP
-	headers, err := c.setupDPoPHeaders()
-	if err != nil {
-		return err
+	if c.FlowConfig.DPoP {
+		req.DPoP = func(method, url string) (string, error) {
+			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
+			if err != nil {
+				return "", err
+			}
+			return proof.String(), nil
+		}
 	}
 
 	// Call the token endpoint with the token exchange request
-	tokenData, err := c.executeTokenRequest(ctx, req, headers)
+	tokenData, err := c.executeTokenRequest(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/oidc/token_refresh.go
+++ b/oidc/token_refresh.go
@@ -20,35 +20,23 @@ type TokenRefreshFlowConfig struct {
 	DPoP         bool
 }
 
-func (c *TokenRefreshFlow) setupDPoPHeaders() (map[string]string, error) {
-	headers := make(map[string]string)
-	if c.FlowConfig.DPoP {
-		dpopProof, err := crypto.NewDPoPProof(
-			c.Config.DPoPPublicKey,
-			c.Config.DPoPPrivateKey,
-			"POST",
-			c.Config.TokenEndpoint,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create DPoP proof: %w", err)
-		}
-		headers["DPoP"] = dpopProof.String()
-	}
-	return headers, nil
-}
-
 func (c *TokenRefreshFlow) Run(ctx context.Context) error {
 	client := c.Config.Client
 
-	// Handle DPoP
-	headers, err := c.setupDPoPHeaders()
-	if err != nil {
-		return err
-	}
-
 	req := httpclient.CreateRefreshTokenRequest(c.Config.ClientID, c.Config.ClientSecret, c.Config.AuthMethod, c.FlowConfig.RefreshToken, c.FlowConfig.Scopes)
 
-	resp, err := client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, req, headers)
+	// Handle DPoP
+	if c.FlowConfig.DPoP {
+		req.DPoP = func(method, url string) (string, error) {
+			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
+			if err != nil {
+				return "", err
+			}
+			return proof.String(), nil
+		}
+	}
+
+	resp, err := client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, req)
 	if err != nil {
 		return fmt.Errorf("token request failed: %w", err)
 	}

--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -1,8 +1,8 @@
 package webflow
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"embed"
 	"errors"
 	"fmt"


### PR DESCRIPTION
This pull request refactors how HTTP headers are handled in device authorization and polling token requests, improving consistency and correctness. 

- Removes the `headers` parameter from the device authorization request methods (not needed)
- Removes the `headers` parameter from token request methods (not needed) 
- Passes DPoP generation as callback function in the `TokenRequest` instead of a static header value so we are able to generate fresh DPoP proof for each token request while polling
- Adds DPoP tests to token client code