### PR TITLE
fix: sign DPoP proofs with the matching algorithm

### DIFF
--- a/crypto/cryptotest/dpop.go
+++ b/crypto/cryptotest/dpop.go
@@ -1,0 +1,216 @@
+// Package cryptotest provides reusable test helpers for asserting that DPoP
+// proofs produced by the crypto package are correct.
+//
+// The helpers parse a proof the way a resource server would — reconstructing
+// the public key from the embedded JWK, verifying the signature against it,
+// and checking the RFC 9449 claim shape — rather than reaching into builder
+// internals. They live in a standalone, importable package so the same
+// assertions can be shared by the crypto tests and the oidc flow tests.
+package cryptotest
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// dpopAlgorithms are the JWS algorithms a DPoP proof may legitimately use.
+// Restricting the parser to this set rejects "none" and any unexpected
+// algorithm before signature verification.
+var dpopAlgorithms = []string{"ES256", "ES384", "ES512", "RS256", "RS384", "RS512", "EdDSA"}
+
+// ErrKeyMismatch is returned by CheckDPoPProof when the proof is valid but its
+// embedded JWK does not match the expected public key. It is a distinct
+// sentinel so negative tests can assert that the key-binding check failed,
+// rather than accepting any verification error.
+var ErrKeyMismatch = errors.New("embedded jwk does not match the expected public key")
+
+// VerifyDPoPProof asserts that proof is a well-formed RFC 9449 DPoP proof bound
+// to pub, failing tb otherwise. It is the assertion-style entry point for
+// happy-path tests; use CheckDPoPProof for negative cases that expect failure.
+func VerifyDPoPProof(tb testing.TB, proof string, pub crypto.PublicKey, wantHTM, wantHTU string) {
+	tb.Helper()
+	if err := CheckDPoPProof(proof, pub, wantHTM, wantHTU); err != nil {
+		tb.Fatalf("DPoP proof verification failed: %v", err)
+	}
+}
+
+// CheckDPoPProof verifies proof the way a resource server would: it parses the
+// JWT, reconstructs the public key from the embedded JWK to check the
+// signature, confirms that key matches pub, and validates the RFC 9449 claim
+// shape (the dpop+jwt header type, the htm/htu claims, a non-empty jti, and a
+// recent iat). It returns a non-nil error describing the first problem found,
+// so callers can assert that verification fails — for example with a
+// mismatched key.
+func CheckDPoPProof(proof string, pub crypto.PublicKey, wantHTM, wantHTU string) error {
+	var embedded crypto.PublicKey
+	token, err := jwt.Parse(proof, func(t *jwt.Token) (any, error) {
+		var keyErr error
+		embedded, keyErr = publicKeyFromJWK(t.Header["jwk"])
+		if keyErr != nil {
+			return nil, keyErr
+		}
+		return embedded, nil
+	}, jwt.WithValidMethods(dpopAlgorithms))
+	if err != nil {
+		return fmt.Errorf("parsing proof: %w", err)
+	}
+
+	if typ, _ := token.Header["typ"].(string); typ != "dpop+jwt" {
+		return fmt.Errorf("header typ = %q, want \"dpop+jwt\"", typ)
+	}
+
+	if !publicKeysEqual(embedded, pub) {
+		return ErrKeyMismatch
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return fmt.Errorf("claims type = %T, want jwt.MapClaims", token.Claims)
+	}
+	if htm, _ := claims["htm"].(string); htm != wantHTM {
+		return fmt.Errorf("htm claim = %q, want %q", htm, wantHTM)
+	}
+	if htu, _ := claims["htu"].(string); htu != wantHTU {
+		return fmt.Errorf("htu claim = %q, want %q", htu, wantHTU)
+	}
+	if jti, _ := claims["jti"].(string); jti == "" {
+		return errors.New("jti claim is missing or empty")
+	}
+	return checkRecentIAT(claims)
+}
+
+// publicKey is the Equal method common to the crypto/ecdsa, crypto/rsa, and
+// crypto/ed25519 public key types, used to compare an embedded key against the
+// expected one.
+type publicKey interface {
+	Equal(x crypto.PublicKey) bool
+}
+
+func publicKeysEqual(a, b crypto.PublicKey) bool {
+	key, ok := a.(publicKey)
+	if !ok {
+		return false
+	}
+	return key.Equal(b)
+}
+
+// publicKeyFromJWK reconstructs a public key from a parsed JWK header value.
+func publicKeyFromJWK(raw any) (crypto.PublicKey, error) {
+	jwk, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("jwk header is missing or not an object (got %T)", raw)
+	}
+	kty, _ := jwk["kty"].(string)
+	switch kty {
+	case "EC":
+		return ecdsaKeyFromJWK(jwk)
+	case "RSA":
+		return rsaKeyFromJWK(jwk)
+	case "OKP":
+		return ed25519KeyFromJWK(jwk)
+	default:
+		return nil, fmt.Errorf("unsupported jwk kty %q", kty)
+	}
+}
+
+func ecdsaKeyFromJWK(jwk map[string]any) (crypto.PublicKey, error) {
+	crv, _ := jwk["crv"].(string)
+	var curve elliptic.Curve
+	switch crv {
+	case "P-256":
+		curve = elliptic.P256()
+	case "P-384":
+		curve = elliptic.P384()
+	case "P-521":
+		curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("unsupported ec curve %q", crv)
+	}
+	x, err := decodeBigInt(jwk, "x")
+	if err != nil {
+		return nil, err
+	}
+	y, err := decodeBigInt(jwk, "y")
+	if err != nil {
+		return nil, err
+	}
+	return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil
+}
+
+func rsaKeyFromJWK(jwk map[string]any) (crypto.PublicKey, error) {
+	n, err := decodeBigInt(jwk, "n")
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := decodeField(jwk, "e")
+	if err != nil {
+		return nil, err
+	}
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() {
+		return nil, errors.New("rsa exponent is out of range")
+	}
+	return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
+}
+
+func ed25519KeyFromJWK(jwk map[string]any) (crypto.PublicKey, error) {
+	b, err := decodeField(jwk, "x")
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("ed25519 public key length = %d, want %d", len(b), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(b), nil
+}
+
+func decodeBigInt(jwk map[string]any, field string) (*big.Int, error) {
+	b, err := decodeField(jwk, field)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(b), nil
+}
+
+func decodeField(jwk map[string]any, field string) ([]byte, error) {
+	s, ok := jwk[field].(string)
+	if !ok {
+		return nil, fmt.Errorf("jwk field %q is missing or not a string", field)
+	}
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("decoding jwk field %q: %w", field, err)
+	}
+	return b, nil
+}
+
+func checkRecentIAT(claims jwt.MapClaims) error {
+	raw, ok := claims["iat"]
+	if !ok {
+		return errors.New("iat claim is missing")
+	}
+	secs, ok := raw.(float64)
+	if !ok {
+		return fmt.Errorf("iat claim type = %T, want a number", raw)
+	}
+	iat := time.Unix(int64(secs), 0)
+	now := time.Now()
+	if iat.After(now.Add(5 * time.Second)) {
+		return fmt.Errorf("iat %s is in the future (now %s)", iat, now)
+	}
+	if now.Sub(iat) > time.Minute {
+		return fmt.Errorf("iat %s is more than a minute in the past (now %s)", iat, now)
+	}
+	return nil
+}

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -156,10 +156,8 @@ func (d *DPoPProofBuilder) parseKeys() error {
 		return fmt.Errorf("unsupported public key type: %T", k)
 	}
 
-	// Derive the signing method from the advertised algorithm so the JWS
-	// header and the signature always agree. Hardcoding a fixed method here
-	// produces proofs that resource servers reject for any key whose alg is
-	// not the default (for example ES384/ES512 or RS384/RS512).
+	// Derive the signing method from the advertised alg; a hardcoded method
+	// would mismatch the header for non-default key sizes and curves.
 	d.signingMethod = jwt.GetSigningMethod(d.alg)
 	if d.signingMethod == nil {
 		return fmt.Errorf("no supported DPoP signing algorithm for key type %T: ECDSA must use P-256, P-384, or P-521, and RSA must be at least 2048 bits", d.publicKey)

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -162,7 +162,7 @@ func (d *DPoPProofBuilder) parseKeys() error {
 	// not the default (for example ES384/ES512 or RS384/RS512).
 	d.signingMethod = jwt.GetSigningMethod(d.alg)
 	if d.signingMethod == nil {
-		return fmt.Errorf("unsupported signing algorithm %q for key", d.alg)
+		return fmt.Errorf("no supported DPoP signing algorithm for key type %T: ECDSA must use P-256, P-384, or P-521, and RSA must be at least 2048 bits", d.publicKey)
 	}
 	return nil
 }

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -135,28 +135,34 @@ func (d *DPoPProofBuilder) parseKeys() error {
 		if _, ok := d.privateKey.(*ecdsa.PrivateKey); !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		d.jwk = ecdsaPublicKeyToJWK(d.publicKey.(*ecdsa.PublicKey))
-		d.alg = ecdsaAlgorithmString(d.publicKey.(*ecdsa.PublicKey))
-		d.signingMethod = jwt.SigningMethodES256
+		d.jwk = ecdsaPublicKeyToJWK(k)
+		d.alg = ecdsaAlgorithmString(k)
 
 	case *rsa.PublicKey:
 		if _, ok := d.privateKey.(*rsa.PrivateKey); !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		d.jwk = rsaPublicKeyToJWK(d.publicKey.(*rsa.PublicKey))
-		d.alg = rsaAlgorithmString(d.publicKey.(*rsa.PublicKey))
-		d.signingMethod = jwt.SigningMethodRS256
+		d.jwk = rsaPublicKeyToJWK(k)
+		d.alg = rsaAlgorithmString(k)
 
 	case ed25519.PublicKey:
 		if _, ok := d.privateKey.(ed25519.PrivateKey); !ok {
 			return errors.New("private key type does not match public key type")
 		}
-		d.jwk = ed25519PublicKeyToJWK(d.publicKey.(ed25519.PublicKey))
+		d.jwk = ed25519PublicKeyToJWK(k)
 		d.alg = ed25519AlgorithmString()
-		d.signingMethod = jwt.SigningMethodEdDSA
 
 	default:
 		return fmt.Errorf("unsupported public key type: %T", k)
+	}
+
+	// Derive the signing method from the advertised algorithm so the JWS
+	// header and the signature always agree. Hardcoding a fixed method here
+	// produces proofs that resource servers reject for any key whose alg is
+	// not the default (for example ES384/ES512 or RS384/RS512).
+	d.signingMethod = jwt.GetSigningMethod(d.alg)
+	if d.signingMethod == nil {
+		return fmt.Errorf("unsupported signing algorithm %q for key", d.alg)
 	}
 	return nil
 }

--- a/crypto/dpop_roundtrip_test.go
+++ b/crypto/dpop_roundtrip_test.go
@@ -1,0 +1,128 @@
+package crypto_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+
+	oidccrypto "github.com/jentz/oidc-cli/crypto"
+	"github.com/jentz/oidc-cli/crypto/cryptotest"
+)
+
+const (
+	dpopMethod = "POST"
+	dpopURL    = "https://as.example.com/token"
+)
+
+// TestNewDPoPProofRoundTrip mints a proof through the public NewDPoPProof API
+// for every supported key type and verifies it by parsing, the way a resource
+// server would. This pins DPoP correctness independent of builder internals.
+func TestNewDPoPProofRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		genKey func(t *testing.T) (pub, priv any)
+	}{
+		{"ECDSA P-256", ecdsaKeyGen(elliptic.P256())},
+		{"ECDSA P-384", ecdsaKeyGen(elliptic.P384())},
+		{"ECDSA P-521", ecdsaKeyGen(elliptic.P521())},
+		{"RSA 2048", rsaKeyGen(2048)},
+		{"RSA 3072", rsaKeyGen(3072)},
+		{"RSA 4096", rsaKeyGen(4096)},
+		{"Ed25519", ed25519KeyGen()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pub, priv := tt.genKey(t)
+
+			proof, err := oidccrypto.NewDPoPProof(pub, priv, dpopMethod, dpopURL)
+			if err != nil {
+				t.Fatalf("NewDPoPProof() error = %v", err)
+			}
+
+			cryptotest.VerifyDPoPProof(t, proof.String(), pub, dpopMethod, dpopURL)
+		})
+	}
+}
+
+// TestNewDPoPProofWrongKey asserts that verification fails when the proof is
+// checked against a public key it is not bound to.
+func TestNewDPoPProofWrongKey(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+
+	proof, err := oidccrypto.NewDPoPProof(&priv.PublicKey, priv, dpopMethod, dpopURL)
+	if err != nil {
+		t.Fatalf("NewDPoPProof() error = %v", err)
+	}
+
+	other, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+
+	// Assert the specific key-binding failure, not merely any error, so the
+	// test cannot pass for an unrelated reason if CheckDPoPProof regresses.
+	if err := cryptotest.CheckDPoPProof(proof.String(), &other.PublicKey, dpopMethod, dpopURL); !errors.Is(err, cryptotest.ErrKeyMismatch) {
+		t.Errorf("CheckDPoPProof() error = %v, want ErrKeyMismatch", err)
+	}
+}
+
+// TestNewDPoPProofUnsupportedKey covers the signing-method guard: a key whose
+// curve maps to no JWS algorithm must produce an error rather than a proof.
+func TestNewDPoPProofUnsupportedKey(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+	}
+
+	if _, err := oidccrypto.NewDPoPProof(&priv.PublicKey, priv, dpopMethod, dpopURL); err == nil {
+		t.Error("NewDPoPProof() error = nil, want error for an unsupported curve")
+	}
+}
+
+func ecdsaKeyGen(curve elliptic.Curve) func(t *testing.T) (pub, priv any) {
+	return func(t *testing.T) (any, any) {
+		t.Helper()
+		priv, err := ecdsa.GenerateKey(curve, rand.Reader)
+		if err != nil {
+			t.Fatalf("ecdsa.GenerateKey() error = %v", err)
+		}
+		return &priv.PublicKey, priv
+	}
+}
+
+func rsaKeyGen(bits int) func(t *testing.T) (pub, priv any) {
+	return func(t *testing.T) (any, any) {
+		t.Helper()
+		priv, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			t.Fatalf("rsa.GenerateKey() error = %v", err)
+		}
+		return &priv.PublicKey, priv
+	}
+}
+
+func ed25519KeyGen() func(t *testing.T) (pub, priv any) {
+	return func(t *testing.T) (any, any) {
+		t.Helper()
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("ed25519.GenerateKey() error = %v", err)
+		}
+		return pub, priv
+	}
+}


### PR DESCRIPTION
## Summary

The DPoP proof builder hardcoded the JWS signing method (`ES256` for ECDSA,
`RS256` for RSA) while advertising a size-appropriate algorithm in the JWT
header. The two disagreed for any key outside the default:

- **ECDSA P-384 / P-521** failed to sign at all (`key is invalid`).
- **RSA 3072 / 4096** produced proofs whose signature did not match the
  advertised `RS384` / `RS512`, so resource servers rejected them.

Only ECDSA P-256, RSA 2048, and Ed25519 happened to work.

## Changes

- Derive the signing method from the advertised algorithm so the header and
  signature always agree, and return a clear error for a key that maps to no
  supported algorithm.
- Add `crypto/cryptotest`, a reusable helper that verifies a DPoP proof the way
  a resource server would: reconstruct the public key from the embedded JWK,
  check the signature, and assert the RFC 9449 claim shape (`dpop+jwt` type,
  `htm`/`htu`, a non-empty `jti`, a recent `iat`).
- Add round-trip tests covering every supported key type (ECDSA P-256/384/521,
  RSA 2048/3072/4096, Ed25519), plus mismatched-key and unsupported-key cases.

## Testing

- `make test`
- `make lint`
