### PR TITLE
feat: make callback server listener injectable

### DIFF
--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -81,6 +81,9 @@ func NewCallbackServer(callbackURI string, logger *log.Logger, opts ...Option) (
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(s)
 	}
 

--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -23,8 +23,8 @@ type CallbackServer struct {
 	path     string
 	server   *http.Server
 	response chan *CallbackResponse
-	// listen is the function to create a network listener. If nil, defaults to net.Listen.
-	// This field allows for dependency injection in tests.
+	// listen creates the server's network listener; NewCallbackServer falls
+	// back to net.Listen when WithListenFunc is not given. Override for tests.
 	listen      func(network, addr string) (net.Listener, error)
 	successTmpl *template.Template
 	errorTmpl   *template.Template
@@ -38,7 +38,20 @@ type CallbackResponse struct {
 	ErrorDescription string
 }
 
-func NewCallbackServer(callbackURI string, logger *log.Logger) (*CallbackServer, error) {
+// Option configures a CallbackServer at construction time.
+type Option func(*CallbackServer)
+
+// WithListenFunc overrides the function the server uses to create its network
+// listener. When not supplied (or nil), NewCallbackServer falls back to
+// net.Listen. Injecting a pre-bound listener lets tests drive the server on an
+// OS-assigned port without depending on the callback URI's port.
+func WithListenFunc(fn func(network, addr string) (net.Listener, error)) Option {
+	return func(s *CallbackServer) {
+		s.listen = fn
+	}
+}
+
+func NewCallbackServer(callbackURI string, logger *log.Logger, opts ...Option) (*CallbackServer, error) {
 	u, err := url.Parse(callbackURI)
 	if err != nil {
 		return nil, fmt.Errorf("invalid callback URI: %w", err)
@@ -58,15 +71,24 @@ func NewCallbackServer(callbackURI string, logger *log.Logger) (*CallbackServer,
 		logger = log.Discard()
 	}
 
-	return &CallbackServer{
+	s := &CallbackServer{
 		host:        u.Host,
 		path:        u.Path,
 		response:    make(chan *CallbackResponse, 1),
-		listen:      net.Listen,
 		successTmpl: successTmpl,
 		errorTmpl:   errorTmpl,
 		logger:      logger,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	if s.listen == nil {
+		s.listen = net.Listen
+	}
+
+	return s, nil
 }
 
 func (s *CallbackServer) Start(ctx context.Context) error {

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -74,6 +74,20 @@ func TestNewCallbackServer(t *testing.T) {
 	}
 }
 
+func TestNewCallbackServerIgnoresNilOption(t *testing.T) {
+	t.Parallel()
+	s, err := NewCallbackServer("http://localhost:8080/callback", nil, nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to parse") {
+			t.Skipf("Skipping due to missing template files: %v", err)
+		}
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.listen == nil {
+		t.Error("nil option must be ignored and listen must fall back to net.Listen")
+	}
+}
+
 func TestCallbackServerStart(t *testing.T) {
 	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)
@@ -130,7 +144,10 @@ func TestCallbackServerStartWithInjectedListener(t *testing.T) {
 			return ln, nil
 		}))
 	if err != nil {
-		t.Skipf("Skipping due to template parsing error: %v", err)
+		if strings.Contains(err.Error(), "failed to parse") {
+			t.Skipf("Skipping due to missing template files: %v", err)
+		}
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -141,9 +158,12 @@ func TestCallbackServerStartWithInjectedListener(t *testing.T) {
 		startErr <- s.Start(ctx)
 	}()
 
-	// Derive the callback URL from the listener's actual address.
+	// Derive the callback URL from the listener's actual address. Bound the
+	// request so a stalled server fails fast instead of hanging the test run.
 	callbackURL := fmt.Sprintf("http://%s/callback?code=abc123&state=xyz", ln.Addr().String())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer reqCancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, callbackURL, nil)
 	if err != nil {
 		t.Fatalf("failed to build request: %v", err)
 	}

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -78,10 +78,7 @@ func TestNewCallbackServerIgnoresNilOption(t *testing.T) {
 	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil, nil)
 	if err != nil {
-		if strings.Contains(err.Error(), "failed to parse") {
-			t.Skipf("Skipping due to missing template files: %v", err)
-		}
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("NewCallbackServer failed: %v", err)
 	}
 	if s.listen == nil {
 		t.Error("nil option must be ignored and listen must fall back to net.Listen")
@@ -144,10 +141,7 @@ func TestCallbackServerStartWithInjectedListener(t *testing.T) {
 			return ln, nil
 		}))
 	if err != nil {
-		if strings.Contains(err.Error(), "failed to parse") {
-			t.Skipf("Skipping due to missing template files: %v", err)
-		}
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("NewCallbackServer failed: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -113,6 +113,77 @@ func TestCallbackServerStart(t *testing.T) {
 	}
 }
 
+func TestCallbackServerStartWithInjectedListener(t *testing.T) {
+	t.Parallel()
+
+	// Pre-bind a listener on an OS-assigned port so the test does not
+	// depend on the callback URI's port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to pre-bind listener: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	// The callback URI carries no port; the injected listener decides it.
+	s, err := NewCallbackServer("http://localhost/callback", nil,
+		WithListenFunc(func(_, _ string) (net.Listener, error) {
+			return ln, nil
+		}))
+	if err != nil {
+		t.Skipf("Skipping due to template parsing error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- s.Start(ctx)
+	}()
+
+	// Derive the callback URL from the listener's actual address.
+	callbackURL := fmt.Sprintf("http://%s/callback?code=abc123&state=xyz", ln.Addr().String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, callbackURL, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("callback request failed: %v", err)
+	}
+	defer func() {
+		if cerr := httpResp.Body.Close(); cerr != nil {
+			t.Errorf("failed to close response body: %v", cerr)
+		}
+	}()
+	if httpResp.StatusCode != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, httpResp.StatusCode)
+	}
+
+	// Bound the wait so a missing callback fails fast instead of blocking on
+	// WaitForCallback's internal five-minute timeout.
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	resp, err := s.WaitForCallback(waitCtx)
+	if err != nil {
+		t.Fatalf("WaitForCallback failed: %v", err)
+	}
+	if resp.Code != "abc123" || resp.State != "xyz" {
+		t.Errorf("expected code=abc123 state=xyz, got code=%q state=%q", resp.Code, resp.State)
+	}
+
+	// Shut the server down and confirm Start returned without a surprise error.
+	cancel()
+	select {
+	case err := <-startErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("Start returned unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("Start did not return after context cancellation")
+	}
+}
+
 func TestCallbackServerStartListenError(t *testing.T) {
 	t.Parallel()
 	s, err := NewCallbackServer("http://localhost:8080/callback", nil)


### PR DESCRIPTION
Expose the callback server's network listener through a functional option so it can be driven deterministically in tests without binding the fixed port from the callback URI.

NewCallbackServer now accepts variadic options, and WithListenFunc overrides how the listener is created, falling back to net.Listen when unset. The change is additive: the existing constructor call site and runtime behavior are unchanged.

Add a test that injects a pre-bound loopback listener on an OS-assigned port and exercises a full callback round-trip.