### PR TITLE
test: characterize the four non-interactive flows

### DIFF
--- a/oidc/client_credentials_test.go
+++ b/oidc/client_credentials_test.go
@@ -1,0 +1,83 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/jentz/oidc-cli/httpclient"
+)
+
+func TestClientCredentialsFlowRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusOK, `{"access_token":"abc123","expires_in":3600,"token_type":"Bearer"}`))
+
+	flow := &ClientCredentialsFlow{
+		Config:     fixture.config,
+		FlowConfig: &ClientCredentialsFlowConfig{Scope: "read write"},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testTokenEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testTokenEndpoint)
+	}
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+
+	wantForm := url.Values{
+		"grant_type": {"client_credentials"},
+		"scope":      {"read write"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	wantOutput := `{
+  "access_token": "abc123",
+  "expires_in": 3600,
+  "token_type": "Bearer"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("output = %q, want %q", got, wantOutput)
+	}
+}
+
+func TestClientCredentialsFlowRunServerError(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusBadRequest, `{"error":"invalid_client","error_description":"bad credentials"}`))
+
+	flow := &ClientCredentialsFlow{
+		Config:     fixture.config,
+		FlowConfig: &ClientCredentialsFlowConfig{},
+	}
+
+	err := flow.Run(context.Background())
+	if !errors.Is(err, httpclient.ErrOAuthError) {
+		t.Fatalf("Run() error = %v, want errors.Is(..., httpclient.ErrOAuthError)", err)
+	}
+
+	// The request is still emitted; only the response surfaces as an error.
+	fixture.onlyRequest(t)
+	if got := fixture.output.String(); got != "" {
+		t.Errorf("output = %q, want empty on error", got)
+	}
+}

--- a/oidc/flow_harness_test.go
+++ b/oidc/flow_harness_test.go
@@ -156,6 +156,9 @@ func captureRequest(t *testing.T, req *http.Request) *capturedRequest {
 	}
 
 	if req.Body != nil {
+		// The RoundTripper contract makes the transport responsible for closing
+		// the request body; honor it even though these test bodies are NopClosers.
+		defer func() { _ = req.Body.Close() }()
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			t.Fatalf("reading request body: %v", err)

--- a/oidc/flow_harness_test.go
+++ b/oidc/flow_harness_test.go
@@ -1,0 +1,186 @@
+package oidc
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/jentz/oidc-cli/httpclient"
+	"github.com/jentz/oidc-cli/log"
+)
+
+// The four non-interactive flows are exercised through their Run entry point
+// against this harness. Tests assert only on what crosses the Run seam — the
+// HTTP request emitted (method, URL, headers, form body) and the bytes written
+// to output — never on config internals or unexported helpers. A later split
+// of the Config struct touches only newReadyConfig (a compile error if missed),
+// not the per-flow assertions, which keep passing on the same wire and output.
+
+const (
+	testClientID              = "test-client"
+	testClientSecret          = "test-secret"
+	testTokenEndpoint         = "https://op.example.com/token"
+	testIntrospectionEndpoint = "https://op.example.com/introspect"
+)
+
+// capturedRequest records the parts of an emitted request that a resource
+// server would see on the wire. The decoded Form is populated for the
+// form-encoded bodies the flows send.
+type capturedRequest struct {
+	Method string
+	URL    string
+	Header http.Header
+	Form   url.Values
+}
+
+// flowFixture bundles a ready Config with the request capture and output buffer
+// that let a flow test assert on the Run seam alone. The requests slice needs
+// no lock because each non-interactive flow drives one synchronous request;
+// capturing concurrent requests would require synchronizing this append.
+type flowFixture struct {
+	config   *Config
+	requests []*capturedRequest
+	output   *bytes.Buffer
+
+	// dpopPublicKey is the key the fixture's DPoP proofs are bound to, set only
+	// when withDPoPKeys is used, so tests can verify the emitted proof.
+	dpopPublicKey any
+}
+
+type fixtureSettings struct {
+	clientID       string
+	clientSecret   string
+	authMethod     httpclient.AuthMethod
+	dpopKeys       bool
+	responseStatus int
+	responseBody   string
+}
+
+type fixtureOption func(*fixtureSettings)
+
+// withAuthMethod overrides the client authentication method (default Basic).
+func withAuthMethod(m httpclient.AuthMethod) fixtureOption {
+	return func(s *fixtureSettings) { s.authMethod = m }
+}
+
+// withDPoPKeys loads a freshly generated ECDSA P-256 keypair into the config,
+// modeling the post-key-load state; the public key is exposed on the fixture.
+func withDPoPKeys() fixtureOption {
+	return func(s *fixtureSettings) { s.dpopKeys = true }
+}
+
+// withResponse sets the canned response the transport returns for every request.
+func withResponse(status int, body string) fixtureOption {
+	return func(s *fixtureSettings) {
+		s.responseStatus = status
+		s.responseBody = body
+	}
+}
+
+// newReadyConfig returns a fixture whose Config is in the state a flow sees
+// after discovery and key loading have run: endpoints populated, credentials
+// and auth method set, optional DPoP keys parsed. The Client is wired to a
+// transport that records every request and replies with the canned response,
+// and the Logger writes to an in-memory buffer.
+func newReadyConfig(t *testing.T, opts ...fixtureOption) *flowFixture {
+	t.Helper()
+
+	settings := &fixtureSettings{
+		clientID:       testClientID,
+		clientSecret:   testClientSecret,
+		authMethod:     httpclient.AuthMethodBasic,
+		responseStatus: http.StatusOK,
+		responseBody:   `{"access_token":"abc123"}`,
+	}
+	for _, opt := range opts {
+		opt(settings)
+	}
+
+	fixture := &flowFixture{output: &bytes.Buffer{}}
+
+	transport := mockTransport(func(req *http.Request) (*http.Response, error) {
+		fixture.requests = append(fixture.requests, captureRequest(t, req))
+		return &http.Response{
+			StatusCode: settings.responseStatus,
+			Body:       io.NopCloser(bytes.NewBufferString(settings.responseBody)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	logger := log.New(log.WithOutput(fixture.output, io.Discard))
+	// The client keeps its own (discard) logger so the output buffer captures
+	// the flow's output alone; the exact-output assertions stay scoped to the
+	// Run seam rather than coupling to any future client-side logging.
+	client := httpclient.NewClient(&httpclient.Config{
+		Transport: transport,
+	})
+
+	fixture.config = &Config{
+		ClientID:              settings.clientID,
+		ClientSecret:          settings.clientSecret,
+		AuthMethod:            settings.authMethod,
+		TokenEndpoint:         testTokenEndpoint,
+		IntrospectionEndpoint: testIntrospectionEndpoint,
+		Client:                client,
+		Logger:                logger,
+	}
+
+	if settings.dpopKeys {
+		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("generating DPoP key: %v", err)
+		}
+		fixture.config.DPoPPublicKey = &priv.PublicKey
+		fixture.config.DPoPPrivateKey = priv
+		fixture.dpopPublicKey = &priv.PublicKey
+	}
+
+	return fixture
+}
+
+// captureRequest snapshots a request as the wire would carry it: method, URL, a
+// copy of the headers, and the form body decoded from the request payload.
+func captureRequest(t *testing.T, req *http.Request) *capturedRequest {
+	t.Helper()
+
+	captured := &capturedRequest{
+		Method: req.Method,
+		URL:    req.URL.String(),
+		Header: req.Header.Clone(),
+	}
+
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parsing request form: %v", err)
+		}
+		captured.Form = form
+	}
+	return captured
+}
+
+// onlyRequest returns the single request the flow was expected to emit, failing
+// if a different number crossed the wire.
+func (f *flowFixture) onlyRequest(t *testing.T) *capturedRequest {
+	t.Helper()
+	if len(f.requests) != 1 {
+		t.Fatalf("got %d emitted requests, want exactly 1", len(f.requests))
+	}
+	return f.requests[0]
+}
+
+// basicAuthHeader is the Authorization header value the fixture's default
+// credentials produce under client_secret_basic.
+func basicAuthHeader() string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(testClientID+":"+testClientSecret))
+}

--- a/oidc/introspect_test.go
+++ b/oidc/introspect_test.go
@@ -1,0 +1,132 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/jentz/oidc-cli/httpclient"
+)
+
+func TestIntrospectFlowRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusOK, `{"active":true,"client_id":"test-client","scope":"read write"}`))
+
+	flow := &IntrospectFlow{
+		Config: fixture.config,
+		FlowConfig: &IntrospectFlowConfig{
+			Token:         "token-to-inspect",
+			TokenTypeHint: "access_token",
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testIntrospectionEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testIntrospectionEndpoint)
+	}
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+	if got := req.Header.Get("Accept"); got != "application/json" {
+		t.Errorf("Accept = %q, want application/json", got)
+	}
+
+	wantForm := url.Values{
+		"token":           {"token-to-inspect"},
+		"token_type_hint": {"access_token"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	wantOutput := `{
+  "active": true,
+  "client_id": "test-client",
+  "scope": "read write"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("output = %q, want %q", got, wantOutput)
+	}
+}
+
+// TestIntrospectFlowRunPostAuth characterizes client_secret_post: credentials
+// ride in the form body and a custom Accept media type is honored.
+func TestIntrospectFlowRunPostAuth(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t, withAuthMethod(httpclient.AuthMethodPost),
+		withResponse(http.StatusOK, `{"active":false}`))
+
+	flow := &IntrospectFlow{
+		Config: fixture.config,
+		FlowConfig: &IntrospectFlowConfig{
+			Token:           "token-to-inspect",
+			AcceptMediaType: "application/token-introspection+jwt",
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testIntrospectionEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testIntrospectionEndpoint)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty for client_secret_post", got)
+	}
+	if got := req.Header.Get("Accept"); got != "application/token-introspection+jwt" {
+		t.Errorf("Accept = %q, want application/token-introspection+jwt", got)
+	}
+
+	wantForm := url.Values{
+		"token":         {"token-to-inspect"},
+		"client_id":     {testClientID},
+		"client_secret": {testClientSecret},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+}
+
+func TestIntrospectFlowRunServerError(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusUnauthorized, `{"error":"invalid_token"}`))
+
+	flow := &IntrospectFlow{
+		Config:     fixture.config,
+		FlowConfig: &IntrospectFlowConfig{Token: "token-to-inspect"},
+	}
+
+	err := flow.Run(context.Background())
+	if !errors.Is(err, httpclient.ErrOAuthError) {
+		t.Fatalf("Run() error = %v, want errors.Is(..., httpclient.ErrOAuthError)", err)
+	}
+
+	fixture.onlyRequest(t)
+	if got := fixture.output.String(); got != "" {
+		t.Errorf("output = %q, want empty on error", got)
+	}
+}

--- a/oidc/token_exchange_test.go
+++ b/oidc/token_exchange_test.go
@@ -1,0 +1,153 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jentz/oidc-cli/crypto/cryptotest"
+)
+
+func TestTokenExchangeFlowRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusOK, `{"access_token":"exchanged","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer"}`))
+
+	flow := &TokenExchangeFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenExchangeFlowConfig{
+			SubjectToken:       "subject-token",
+			SubjectTokenType:   "urn:ietf:params:oauth:token-type:access_token",
+			RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			Audience:           "https://api.example.com",
+			Scope:              "read",
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testTokenEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testTokenEndpoint)
+	}
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+
+	wantForm := url.Values{
+		"grant_type":           {"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"subject_token":        {"subject-token"},
+		"subject_token_type":   {"urn:ietf:params:oauth:token-type:access_token"},
+		"requested_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+		"audience":             {"https://api.example.com"},
+		"scope":                {"read"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	wantOutput := `{
+  "access_token": "exchanged",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("output = %q, want %q", got, wantOutput)
+	}
+}
+
+func TestTokenExchangeFlowRunDPoP(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t, withDPoPKeys(),
+		withResponse(http.StatusOK, `{"access_token":"exchanged","token_type":"DPoP"}`))
+
+	flow := &TokenExchangeFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenExchangeFlowConfig{
+			SubjectToken:     "subject-token",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			DPoP:             true,
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testTokenEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testTokenEndpoint)
+	}
+
+	// Client authentication and content type must survive on the DPoP path,
+	// not just the proof header — a DPoP-specific regression could drop them.
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+
+	// The form must stay intact on the DPoP path, not just the proof header.
+	wantForm := url.Values{
+		"grant_type":         {"urn:ietf:params:oauth:grant-type:token-exchange"},
+		"subject_token":      {"subject-token"},
+		"subject_token_type": {"urn:ietf:params:oauth:token-type:access_token"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	// VerifyDPoPProof fails on an empty proof, so it doubles as the presence check.
+	cryptotest.VerifyDPoPProof(t, req.Header.Get("DPoP"), fixture.dpopPublicKey, http.MethodPost, testTokenEndpoint)
+}
+
+// TestTokenExchangeFlowRunDPoPWithoutKeys pins the current behavior that asking
+// for DPoP without loaded keys fails at send time, before any request is made.
+func TestTokenExchangeFlowRunDPoPWithoutKeys(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t)
+
+	flow := &TokenExchangeFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenExchangeFlowConfig{
+			SubjectToken:     "subject-token",
+			SubjectTokenType: "urn:ietf:params:oauth:token-type:access_token",
+			DPoP:             true,
+		},
+	}
+
+	err := flow.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for DPoP with absent keys")
+	}
+	// Pin that the failure is the proof generation, not some incidental error.
+	if !strings.Contains(err.Error(), "DPoP proof") {
+		t.Errorf("error = %q, want it to mention DPoP proof generation", err)
+	}
+
+	if len(fixture.requests) != 0 {
+		t.Errorf("emitted %d requests, want 0 when proof generation fails", len(fixture.requests))
+	}
+	if got := fixture.output.String(); got != "" {
+		t.Errorf("output = %q, want empty on error", got)
+	}
+}

--- a/oidc/token_refresh_test.go
+++ b/oidc/token_refresh_test.go
@@ -1,0 +1,144 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jentz/oidc-cli/crypto/cryptotest"
+)
+
+func TestTokenRefreshFlowRun(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t,
+		withResponse(http.StatusOK, `{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer"}`))
+
+	flow := &TokenRefreshFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenRefreshFlowConfig{
+			RefreshToken: "old-refresh",
+			Scope:        "read write",
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testTokenEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testTokenEndpoint)
+	}
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+
+	wantForm := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {"old-refresh"},
+		"scope":         {"read write"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	wantOutput := `{
+  "access_token": "new-access",
+  "refresh_token": "new-refresh",
+  "token_type": "Bearer"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("output = %q, want %q", got, wantOutput)
+	}
+}
+
+func TestTokenRefreshFlowRunDPoP(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t, withDPoPKeys(),
+		withResponse(http.StatusOK, `{"access_token":"new-access","token_type":"DPoP"}`))
+
+	flow := &TokenRefreshFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenRefreshFlowConfig{
+			RefreshToken: "old-refresh",
+			DPoP:         true,
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	req := fixture.onlyRequest(t)
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", req.Method)
+	}
+	if req.URL != testTokenEndpoint {
+		t.Errorf("url = %q, want %q", req.URL, testTokenEndpoint)
+	}
+
+	// Client authentication and content type must survive on the DPoP path,
+	// not just the proof header — a DPoP-specific regression could drop them.
+	if got := req.Header.Get("Authorization"); got != basicAuthHeader() {
+		t.Errorf("Authorization = %q, want %q", got, basicAuthHeader())
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", got)
+	}
+
+	// The form must stay intact on the DPoP path, not just the proof header.
+	wantForm := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {"old-refresh"},
+	}
+	if !reflect.DeepEqual(req.Form, wantForm) {
+		t.Errorf("form = %v, want %v", req.Form, wantForm)
+	}
+
+	// VerifyDPoPProof fails on an empty proof, so it doubles as the presence check.
+	cryptotest.VerifyDPoPProof(t, req.Header.Get("DPoP"), fixture.dpopPublicKey, http.MethodPost, testTokenEndpoint)
+}
+
+// TestTokenRefreshFlowRunDPoPWithoutKeys pins the current behavior that asking
+// for DPoP without loaded keys fails at send time, before any request is made.
+func TestTokenRefreshFlowRunDPoPWithoutKeys(t *testing.T) {
+	t.Parallel()
+
+	fixture := newReadyConfig(t)
+
+	flow := &TokenRefreshFlow{
+		Config: fixture.config,
+		FlowConfig: &TokenRefreshFlowConfig{
+			RefreshToken: "old-refresh",
+			DPoP:         true,
+		},
+	}
+
+	err := flow.Run(context.Background())
+	if err == nil {
+		t.Fatal("Run() error = nil, want error for DPoP with absent keys")
+	}
+	// Pin that the failure is the proof generation, not some incidental error.
+	if !strings.Contains(err.Error(), "DPoP proof") {
+		t.Errorf("error = %q, want it to mention DPoP proof generation", err)
+	}
+
+	if len(fixture.requests) != 0 {
+		t.Errorf("emitted %d requests, want 0 when proof generation fails", len(fixture.requests))
+	}
+	if got := fixture.output.String(); got != "" {
+		t.Errorf("output = %q, want empty on error", got)
+	}
+}


### PR DESCRIPTION
## What

Adds a flow test harness and characterization tests for the four
non-interactive OIDC flows — `client_credentials`, `token_refresh`,
`token_exchange`, and `introspect` — each exercised end-to-end through
its `Run` entry point.

## How

A single `newReadyConfig(t, opts...)` fixture builds a ready
(post-discovery, post-key-load) config wired to a request-capturing
transport and an in-memory output buffer. Tests assert only on what
crosses the `Run` seam:

- the HTTP request emitted — method, URL, headers, and decoded form body
- the exact bytes written to output (2-space indent, sorted keys, trailing newline)

Coupling to the wire and output alone — never to config internals or
unexported helpers — keeps the suite intact across later behavior-preserving
refactors.

For the DPoP-capable flows (`token_refresh`, `token_exchange`), the emitted
`DPoP` header is **verified** with the proof verifier (signature + RFC 9449
claims + key binding), not just checked for presence. The current behavior of
requesting DPoP without loaded keys — an error at send time, before any request
is made — is pinned as-is.

## Notes

- **No production code is changed.** These are characterization tests.
- `oidc` package coverage rises from ~10% to ~33%.
- Error paths assert the wrapped sentinel (`errors.Is(..., ErrOAuthError)`)
  rather than mere error presence, so a regression in error classification is
  caught.
- `make test` (race) and `make lint` pass.