### PR TITLE
refactor: give DPoP, output, PKCE one home each

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -104,6 +105,17 @@ func (l *Logger) Outputf(format string, args ...interface{}) {
 // Outputln writes line output to stdout (always).
 func (l *Logger) Outputln(args ...interface{}) {
 	_, _ = fmt.Fprintln(l.stdOut, args...)
+}
+
+// OutputJSON renders v as indented JSON followed by a newline to stdout. It is
+// the shared tail for flows that print a response.
+func (l *Logger) OutputJSON(v any) error {
+	prettyJSON, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format JSON output: %w", err)
+	}
+	l.Outputf("%s\n", string(prettyJSON))
+	return nil
 }
 
 // Verbosef writes formatted output to stdout (only in verbose mode)

--- a/log/log.go
+++ b/log/log.go
@@ -112,7 +112,7 @@ func (l *Logger) Outputln(args ...interface{}) {
 func (l *Logger) OutputJSON(v any) error {
 	prettyJSON, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to format JSON output: %w", err)
+		return fmt.Errorf("failed to format %T as JSON: %w", v, err)
 	}
 	l.Outputf("%s\n", string(prettyJSON))
 	return nil

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -198,7 +198,7 @@ func TestOutputJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("returns an error for an unmarshalable value", func(t *testing.T) {
+	t.Run("returns an error when the value cannot be marshaled", func(t *testing.T) {
 		t.Parallel()
 		logger, _, outBuf := setupTestLogger(false)
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -207,8 +207,13 @@ func TestOutputJSON(t *testing.T) {
 		if err == nil {
 			t.Fatal("OutputJSON error = nil, want error when the value cannot be marshaled")
 		}
-		if !strings.Contains(err.Error(), "failed to format JSON output") {
+		if !strings.Contains(err.Error(), "failed to format") {
 			t.Errorf("error = %q, want it to mention JSON formatting", err)
+		}
+		// The message names the concrete type so a failure points at the
+		// offending value, not just "something didn't marshal".
+		if !strings.Contains(err.Error(), "chan int") {
+			t.Errorf("error = %q, want it to name the offending type", err)
 		}
 		if got := outBuf.String(); got != "" {
 			t.Errorf("stdout = %q, want empty on error", got)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -171,6 +171,51 @@ func TestOutputLogging(t *testing.T) {
 	}
 }
 
+func TestOutputJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renders indented JSON with a trailing newline", func(t *testing.T) {
+		t.Parallel()
+		logger, errBuf, outBuf := setupTestLogger(false)
+
+		err := logger.OutputJSON(map[string]any{
+			"access_token": "abc123",
+			"expires_in":   3600,
+		})
+		if err != nil {
+			t.Fatalf("OutputJSON returned error: %v", err)
+		}
+
+		// Pin the exact bytes a flow emits: two-space indent, keys sorted by the
+		// encoder, one trailing newline. This is the contract the flow tails rely
+		// on staying byte-for-byte stable.
+		want := "{\n  \"access_token\": \"abc123\",\n  \"expires_in\": 3600\n}\n"
+		if got := outBuf.String(); got != want {
+			t.Errorf("stdout = %q, want %q", got, want)
+		}
+		if got := errBuf.String(); got != "" {
+			t.Errorf("stderr = %q, want empty", got)
+		}
+	})
+
+	t.Run("returns an error for an unmarshalable value", func(t *testing.T) {
+		t.Parallel()
+		logger, _, outBuf := setupTestLogger(false)
+
+		// A channel cannot be marshaled, so MarshalIndent fails.
+		err := logger.OutputJSON(make(chan int))
+		if err == nil {
+			t.Fatal("OutputJSON error = nil, want error for unmarshalable value")
+		}
+		if !strings.Contains(err.Error(), "failed to format JSON output") {
+			t.Errorf("error = %q, want it to mention JSON formatting", err)
+		}
+		if got := outBuf.String(); got != "" {
+			t.Errorf("stdout = %q, want empty on error", got)
+		}
+	})
+}
+
 func TestVerboseOutputLogging(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -205,7 +205,7 @@ func TestOutputJSON(t *testing.T) {
 		// A channel cannot be marshaled, so MarshalIndent fails.
 		err := logger.OutputJSON(make(chan int))
 		if err == nil {
-			t.Fatal("OutputJSON error = nil, want error for unmarshalable value")
+			t.Fatal("OutputJSON error = nil, want error when the value cannot be marshaled")
 		}
 		if !strings.Contains(err.Error(), "failed to format JSON output") {
 			t.Errorf("error = %q, want it to mention JSON formatting", err)

--- a/oidc/authorization_code.go
+++ b/oidc/authorization_code.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/jentz/oidc-cli/crypto"
@@ -28,20 +27,6 @@ type AuthorizationCodeFlowConfig struct {
 	PKCE        bool
 	PAR         bool
 	DPoP        bool
-}
-
-func (c *AuthorizationCodeFlow) setupPKCE() (string, error) {
-	if !c.FlowConfig.PKCE {
-		return "", nil
-	}
-	if c.Config.ClientSecret == "" {
-		c.Config.AuthMethod = httpclient.AuthMethodNone
-	}
-	codeVerifier, err := crypto.GeneratePKCECodeVerifier()
-	if err != nil {
-		return "", fmt.Errorf("failed to generate PKCE code verifier: %w", err)
-	}
-	return codeVerifier, nil
 }
 
 func (c *AuthorizationCodeFlow) createAuthCodeRequest(ctx context.Context, codeVerifier string) (*httpclient.AuthorizationCodeRequest, error) {
@@ -120,7 +105,7 @@ func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, c
 
 func (c *AuthorizationCodeFlow) Run(ctx context.Context) error {
 	// Handle PKCE
-	codeVerifier, err := c.setupPKCE()
+	codeVerifier, err := c.Config.setupPKCE(c.FlowConfig.PKCE)
 	if err != nil {
 		return err
 	}
@@ -137,13 +122,7 @@ func (c *AuthorizationCodeFlow) Run(ctx context.Context) error {
 	// Handle DPoP
 	var dpopFunc httpclient.DPoPProofFunc
 	if c.FlowConfig.DPoP {
-		dpopFunc = func(method, url string) (string, error) {
-			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
-			if err != nil {
-				return "", err
-			}
-			return proof.String(), nil
-		}
+		dpopFunc = c.Config.DPoPKeys.ProofFunc()
 	}
 	// Exchange authorization code for access token
 	tokenData, err := c.executeTokenRequest(ctx, authResp.Code, codeVerifier, dpopFunc)
@@ -151,11 +130,5 @@ func (c *AuthorizationCodeFlow) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format token response: %w", err)
-	}
-	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return c.Config.Logger.OutputJSON(tokenData)
 }

--- a/oidc/client_credentials.go
+++ b/oidc/client_credentials.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/jentz/oidc-cli/httpclient"
@@ -37,11 +36,5 @@ func (c *ClientCredentialsFlow) Run(ctx context.Context) error {
 		return httpclient.WrapError(err, "token")
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format token response: %w", err)
-	}
-	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return c.Config.Logger.OutputJSON(tokenData)
 }

--- a/oidc/device.go
+++ b/oidc/device.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/jentz/oidc-cli/crypto"
@@ -20,23 +19,9 @@ type DeviceFlowConfig struct {
 	PKCE  bool
 }
 
-func (c *DeviceFlow) setupPKCE() (string, error) {
-	if !c.FlowConfig.PKCE {
-		return "", nil
-	}
-	if c.Config.ClientSecret == "" {
-		c.Config.AuthMethod = httpclient.AuthMethodNone
-	}
-	codeVerifier, err := crypto.GeneratePKCECodeVerifier()
-	if err != nil {
-		return "", fmt.Errorf("failed to generate PKCE code verifier: %w", err)
-	}
-	return codeVerifier, nil
-}
-
 func (c *DeviceFlow) Run(ctx context.Context) error {
 	client := c.Config.Client
-	codeVerifier, err := c.setupPKCE()
+	codeVerifier, err := c.Config.setupPKCE(c.FlowConfig.PKCE)
 	if err != nil {
 		return err
 	}
@@ -86,13 +71,7 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 	)
 
 	if c.FlowConfig.DPoP {
-		tokenReq.DPoP = func(method, url string) (string, error) {
-			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
-			if err != nil {
-				return "", err
-			}
-			return proof.String(), nil
-		}
+		tokenReq.DPoP = c.Config.DPoPKeys.ProofFunc()
 	}
 
 	tokenResp, err := client.ExecutePollingTokenRequest(ctx, c.Config.TokenEndpoint, tokenReq, deviceAuthResp.Interval)
@@ -104,11 +83,5 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 		return httpclient.WrapError(err, "token")
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format token response: %w", err)
-	}
-	logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return logger.OutputJSON(tokenData)
 }

--- a/oidc/device_test.go
+++ b/oidc/device_test.go
@@ -133,6 +133,64 @@ func TestDeviceFlowRunVerificationURIComplete(t *testing.T) {
 	}
 }
 
+// TestDeviceFlowRunPublicClient pins the PKCE no-secret fallback on the device
+// flow: with no client secret, the shared PKCE setup switches to no client
+// authentication, so the polling token request carries client_id in the body
+// and no Authorization header, and PKCE rides both the device-authorization and
+// token requests.
+func TestDeviceFlowRunPublicClient(t *testing.T) {
+	t.Parallel()
+
+	deviceAuthBody := `{"device_code":"dev-code-1","verification_uri":"https://op.example.com/device","interval":5,"expires_in":1800}`
+
+	fixture := newReadyConfig(t,
+		withPublicClient(),
+		withBrowser(&recordingBrowser{}),
+		withRoute(testDeviceAuthEndpoint, http.StatusOK, deviceAuthBody),
+		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
+	)
+
+	flow := &DeviceFlow{
+		Config: fixture.config,
+		FlowConfig: &DeviceFlowConfig{
+			Scope: "openid",
+			PKCE:  true,
+		},
+	}
+
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(fixture.requests) != 2 {
+		t.Fatalf("got %d emitted requests, want 2 (device-auth + token)", len(fixture.requests))
+	}
+	deviceReq, tokenReq := fixture.requests[0], fixture.requests[1]
+
+	// PKCE must reach the device-authorization request as an S256 challenge.
+	if got := deviceReq.Form.Get("code_challenge_method"); got != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", got)
+	}
+	if deviceReq.Form.Get("code_challenge") == "" {
+		t.Error("code_challenge is empty, want the PKCE challenge on the device-auth request")
+	}
+
+	// Public-client token request: no client authentication header, client_id in
+	// the body, no client_secret, and the PKCE verifier present.
+	if got := tokenReq.Header.Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want no header for a public client", got)
+	}
+	if got := tokenReq.Form.Get("client_id"); got != testClientID {
+		t.Errorf("client_id = %q, want %q in the body", got, testClientID)
+	}
+	if tokenReq.Form.Has("client_secret") {
+		t.Errorf("client_secret = %q, want absent for a public client", tokenReq.Form.Get("client_secret"))
+	}
+	if tokenReq.Form.Get("code_verifier") == "" {
+		t.Error("code_verifier is empty, want the PKCE verifier on the token request")
+	}
+}
+
 // TestDeviceFlowRunDPoP verifies the polling token request carries a valid DPoP
 // proof bound to the configured key.
 func TestDeviceFlowRunDPoP(t *testing.T) {

--- a/oidc/dpop_keys.go
+++ b/oidc/dpop_keys.go
@@ -1,0 +1,27 @@
+package oidc
+
+import (
+	"github.com/jentz/oidc-cli/crypto"
+	"github.com/jentz/oidc-cli/httpclient"
+)
+
+// DPoPKeys holds the parsed DPoP keypair and vends the proof function that
+// signs each token request. The zero value carries no keys, so its proof
+// function errors rather than emitting an unsigned proof.
+type DPoPKeys struct {
+	Public  any
+	Private any
+}
+
+// ProofFunc returns a function that mints a fresh DPoP proof for each token
+// request, signed with the loaded keypair. It errors when a key is absent
+// rather than emitting an unsigned proof.
+func (k DPoPKeys) ProofFunc() httpclient.DPoPProofFunc {
+	return func(method, url string) (string, error) {
+		proof, err := crypto.NewDPoPProof(k.Public, k.Private, method, url)
+		if err != nil {
+			return "", err
+		}
+		return proof.String(), nil
+	}
+}

--- a/oidc/dpop_keys_test.go
+++ b/oidc/dpop_keys_test.go
@@ -1,0 +1,98 @@
+package oidc
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/jentz/oidc-cli/crypto/cryptotest"
+)
+
+// TestDPoPKeysProofFuncSignsWithLoadedKeys checks that the proof function the
+// owner vends produces a proof a resource server accepts: bound to the loaded
+// public key, with the method and endpoint it was asked to sign.
+func TestDPoPKeysProofFuncSignsWithLoadedKeys(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	keys := DPoPKeys{Public: &priv.PublicKey, Private: priv}
+
+	const (
+		method = "POST"
+		url    = "https://op.example.com/token"
+	)
+
+	proof, err := keys.ProofFunc()(method, url)
+	if err != nil {
+		t.Fatalf("ProofFunc returned error: %v", err)
+	}
+	cryptotest.VerifyDPoPProof(t, proof, &priv.PublicKey, method, url)
+}
+
+// TestDPoPKeysProofFuncWithoutKeys pins that a proof function vended without a
+// loaded keypair fails loudly instead of emitting an unsigned or empty proof.
+func TestDPoPKeysProofFuncWithoutKeys(t *testing.T) {
+	t.Parallel()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		keys DPoPKeys
+		// wantContain are substrings the error must name; wantAbsent are the
+		// substrings it must not, so a one-key case cannot pass on the other
+		// key's message if the two were ever swapped.
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:        "both keys absent",
+			keys:        DPoPKeys{},
+			wantContain: []string{"publicKey cannot be nil", "privateKey cannot be nil"},
+		},
+		{
+			name:        "private key absent",
+			keys:        DPoPKeys{Public: &priv.PublicKey},
+			wantContain: []string{"privateKey cannot be nil"},
+			wantAbsent:  []string{"publicKey cannot be nil"},
+		},
+		{
+			name:        "public key absent",
+			keys:        DPoPKeys{Private: priv},
+			wantContain: []string{"publicKey cannot be nil"},
+			wantAbsent:  []string{"privateKey cannot be nil"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			proof, err := tt.keys.ProofFunc()("POST", "https://op.example.com/token")
+			if err == nil {
+				t.Fatal("ProofFunc error = nil, want error for absent key")
+			}
+			for _, want := range tt.wantContain {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to contain %q", err, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(err.Error(), absent) {
+					t.Errorf("error = %q, want it to omit %q", err, absent)
+				}
+			}
+			if proof != "" {
+				t.Errorf("proof = %q, want empty on error", proof)
+			}
+		})
+	}
+}

--- a/oidc/flow_harness_test.go
+++ b/oidc/flow_harness_test.go
@@ -193,8 +193,7 @@ func newReadyConfig(t *testing.T, opts ...fixtureOption) *flowFixture {
 		if err != nil {
 			t.Fatalf("generating DPoP key: %v", err)
 		}
-		fixture.config.DPoPPublicKey = &priv.PublicKey
-		fixture.config.DPoPPrivateKey = priv
+		fixture.config.DPoPKeys = DPoPKeys{Public: &priv.PublicKey, Private: priv}
 		fixture.dpopPublicKey = &priv.PublicKey
 	}
 

--- a/oidc/introspect.go
+++ b/oidc/introspect.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/jentz/oidc-cli/httpclient"
@@ -45,11 +44,5 @@ func (c *IntrospectFlow) Run(ctx context.Context) error {
 		return httpclient.WrapError(err, "introspection")
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(introspectionData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format introspection response: %w", err)
-	}
-	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return c.Config.Logger.OutputJSON(introspectionData)
 }

--- a/oidc/oidc_config.go
+++ b/oidc/oidc_config.go
@@ -124,12 +124,14 @@ func (c *Config) setupPKCE(enabled bool) (string, error) {
 	if !enabled {
 		return "", nil
 	}
-	if c.ClientSecret == "" {
-		c.AuthMethod = httpclient.AuthMethodNone
-	}
 	codeVerifier, err := crypto.GeneratePKCECodeVerifier()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate PKCE code verifier: %w", err)
+	}
+	// Flip the auth method only after the fallible step, so a failed generation
+	// leaves the config untouched.
+	if c.ClientSecret == "" {
+		c.AuthMethod = httpclient.AuthMethodNone
 	}
 	return codeVerifier, nil
 }

--- a/oidc/oidc_config.go
+++ b/oidc/oidc_config.go
@@ -106,11 +106,11 @@ func (c *Config) ReadKeyFiles() error {
 	if c.DPoPPublicKeyFile != "" {
 		pem, err := crypto.ReadPEMBlockFromFile(c.DPoPPublicKeyFile)
 		if err != nil {
-			return fmt.Errorf("failed to read public key file: %v", err)
+			return fmt.Errorf("failed to read public key file: %w", err)
 		}
 		c.DPoPKeys.Public, err = crypto.ParsePublicKeyPEMBlock(pem)
 		if err != nil {
-			return fmt.Errorf("failed to parse public key: %v", err)
+			return fmt.Errorf("failed to parse public key: %w", err)
 		}
 	}
 	return nil

--- a/oidc/oidc_config.go
+++ b/oidc/oidc_config.go
@@ -25,8 +25,7 @@ type Config struct {
 	AuthMethod                         httpclient.AuthMethod
 	DPoPPrivateKeyFile                 string
 	DPoPPublicKeyFile                  string
-	DPoPPrivateKey                     any
-	DPoPPublicKey                      any
+	DPoPKeys                           DPoPKeys
 	Client                             *httpclient.Client
 	Logger                             *log.Logger
 }
@@ -97,7 +96,7 @@ func (c *Config) ReadKeyFiles() error {
 		if err != nil {
 			return fmt.Errorf("could not read private key file: %w", err)
 		}
-		c.DPoPPrivateKey, err = crypto.ParsePrivateKeyPEMBlock(pem)
+		c.DPoPKeys.Private, err = crypto.ParsePrivateKeyPEMBlock(pem)
 		if err != nil {
 			return fmt.Errorf("could not parse private key: %w", err)
 		}
@@ -109,10 +108,28 @@ func (c *Config) ReadKeyFiles() error {
 		if err != nil {
 			return fmt.Errorf("failed to read public key file: %v", err)
 		}
-		c.DPoPPublicKey, err = crypto.ParsePublicKeyPEMBlock(pem)
+		c.DPoPKeys.Public, err = crypto.ParsePublicKeyPEMBlock(pem)
 		if err != nil {
 			return fmt.Errorf("failed to parse public key: %v", err)
 		}
 	}
 	return nil
+}
+
+// setupPKCE generates a PKCE code verifier when enabled, returning an empty
+// verifier when not. A client with no secret cannot authenticate at the token
+// endpoint, so PKCE secures a public client and the auth method falls back to
+// none.
+func (c *Config) setupPKCE(enabled bool) (string, error) {
+	if !enabled {
+		return "", nil
+	}
+	if c.ClientSecret == "" {
+		c.AuthMethod = httpclient.AuthMethodNone
+	}
+	codeVerifier, err := crypto.GeneratePKCECodeVerifier()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate PKCE code verifier: %w", err)
+	}
+	return codeVerifier, nil
 }

--- a/oidc/token_exchange.go
+++ b/oidc/token_exchange.go
@@ -2,10 +2,8 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
 )
 
@@ -66,13 +64,7 @@ func (c *TokenExchangeFlow) Run(ctx context.Context) error {
 
 	// Handle DPoP
 	if c.FlowConfig.DPoP {
-		req.DPoP = func(method, url string) (string, error) {
-			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
-			if err != nil {
-				return "", err
-			}
-			return proof.String(), nil
-		}
+		req.DPoP = c.Config.DPoPKeys.ProofFunc()
 	}
 
 	// Call the token endpoint with the token exchange request
@@ -81,11 +73,5 @@ func (c *TokenExchangeFlow) Run(ctx context.Context) error {
 		return err
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format token response: %w", err)
-	}
-	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return c.Config.Logger.OutputJSON(tokenData)
 }

--- a/oidc/token_refresh.go
+++ b/oidc/token_refresh.go
@@ -2,10 +2,8 @@ package oidc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
 )
 
@@ -27,13 +25,7 @@ func (c *TokenRefreshFlow) Run(ctx context.Context) error {
 
 	// Handle DPoP
 	if c.FlowConfig.DPoP {
-		req.DPoP = func(method, url string) (string, error) {
-			proof, err := crypto.NewDPoPProof(c.Config.DPoPPublicKey, c.Config.DPoPPrivateKey, method, url)
-			if err != nil {
-				return "", err
-			}
-			return proof.String(), nil
-		}
+		req.DPoP = c.Config.DPoPKeys.ProofFunc()
 	}
 
 	resp, err := client.ExecuteTokenRequest(ctx, c.Config.TokenEndpoint, req)
@@ -46,11 +38,5 @@ func (c *TokenRefreshFlow) Run(ctx context.Context) error {
 		return httpclient.WrapError(err, "token")
 	}
 
-	// Print available response data
-	prettyJSON, err := json.MarshalIndent(tokenData, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to format token response: %w", err)
-	}
-	c.Config.Logger.Outputf("%s\n", string(prettyJSON))
-	return nil
+	return c.Config.Logger.OutputJSON(tokenData)
 }


### PR DESCRIPTION
## What

The six OIDC flows each carried the same request tail, copied inline:

- a DPoP proof closure (four flows),
- a marshal-and-print block (all six),
- a PKCE setup (the two PKCE-capable flows).

This gives each one a single home:

- **`DPoPKeys`** holds the parsed keypair and vends the proof function;
  the four inline closures now call `DPoPKeys.ProofFunc()`. `Config`
  carries a single `DPoPKeys` field in place of the separate parsed-key
  fields.
- **`Logger.OutputJSON`** renders a value as indented JSON, replacing the
  six marshal-and-print tails with byte-for-byte identical output.
- **`Config.setupPKCE`** generates the verifier and applies the no-secret
  fallback to no client authentication, replacing the two copies.

## Why

Removes duplication that had to be kept in sync by hand across every flow,
giving DPoP proof generation, response output, and PKCE setup one tested
home each.

## Behavior

Unchanged at the wire and on stdout — a pure refactor.

## Tests

- Direct tests for `DPoPKeys.ProofFunc` (a verified proof and the
  absent-key error paths).
- A direct `Logger.OutputJSON` test pinning the exact output bytes and the
  marshal-error path.
- A device public-client PKCE test pinning the no-secret to no-auth
  fallback end-to-end.

`make test` (race) and `make lint` pass.
