### PR TITLE
fix: treat --skip-tls-verify as a global-only flag

### DIFF
--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -32,9 +32,6 @@ func parseAuthorizationCodeFlags(in ParseInput) (runner CommandRunner, output st
 	flags.StringVar(&oidcConf.OIDC.TokenEndpoint, "token-url", "", "override token url")
 	flags.StringVar(&oidcConf.OIDC.ClientID, "client-id", oidcConf.OIDC.ClientID, "set client ID (required)")
 	flags.StringVar(&oidcConf.OIDC.ClientSecret, "client-secret", oidcConf.OIDC.ClientSecret, "set client secret (required if not using PKCE)")
-	// Effective only as a global flag (the client is built before subcommands parse); accepted here but ignored.
-	var skipTLSVerify bool
-	flags.BoolVar(&skipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
 	flags.Var(&oidcConf.OIDC.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 	flags.StringVar(&oidcConf.DPoPKeys.PrivateKeyFile, "dpop-private-key", "", "file to read private key from (eg. for DPoP)")
 	flags.StringVar(&oidcConf.DPoPKeys.PublicKeyFile, "dpop-public-key", "", "file to read public key from (eg. for DPoP)")

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -24,7 +24,6 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
 				"--authorization-url", "https://example.com/authorize",
 				"--token-url", "https://example.com/token",
-				"--skip-tls-verify",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"--scope", "openid profile email",
@@ -291,6 +290,34 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				t.Errorf("OIDCConfig got %+v, want %+v", *f.FlowConfig, tt.flowConf)
 			}
 		})
+	}
+}
+
+// --skip-tls-verify is a global-only flag, so the authorization_code subcommand
+// must reject it. The other args are valid, so the sole parse error is the
+// undefined flag.
+func TestParseAuthorizationCodeFlagsRejectsSkipTLSVerify(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"--issuer", "https://example.com",
+		"--client-id", "client-id",
+		"--client-secret", "client-secret",
+		"--scope", "openid",
+		"--callback-uri", "http://localhost:8080/callback",
+		"--skip-tls-verify",
+	}
+	runner, output, err := parseAuthorizationCodeFlags(ParseInput{Name: "authorization_code", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
+	if err == nil {
+		t.Fatal("err got nil, want unknown-flag error for --skip-tls-verify")
+	}
+	if !strings.Contains(err.Error(), "skip-tls-verify") {
+		t.Errorf("err got %v, want it to name the undefined skip-tls-verify flag", err)
+	}
+	if runner != nil {
+		t.Errorf("runner got %T, want nil on parse failure", runner)
+	}
+	if output == "" {
+		t.Error("output got empty, want usage text on parse failure")
 	}
 }
 

--- a/cmd/device_cfg.go
+++ b/cmd/device_cfg.go
@@ -21,9 +21,6 @@ func parseDeviceFlags(in ParseInput) (runner CommandRunner, output string, err e
 	flags.StringVar(&oidcConf.OIDC.DeviceAuthorizationEndpoint, "device-authorization-url", "", "override device authorization url")
 	flags.StringVar(&oidcConf.OIDC.ClientID, "client-id", oidcConf.OIDC.ClientID, "set client ID (required)")
 	flags.StringVar(&oidcConf.OIDC.ClientSecret, "client-secret", oidcConf.OIDC.ClientSecret, "set client secret (required if not using PKCE)")
-	// Effective only as a global flag (the client is built before subcommands parse); accepted here but ignored.
-	var skipTLSVerify bool
-	flags.BoolVar(&skipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
 	flags.Var(&oidcConf.OIDC.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 	flags.StringVar(&oidcConf.DPoPKeys.PrivateKeyFile, "dpop-private-key", "", "file to read private key from (eg. for DPoP)")
 	flags.StringVar(&oidcConf.DPoPKeys.PublicKeyFile, "dpop-public-key", "", "file to read public key from (eg. for DPoP)")

--- a/cmd/device_cfg_test.go
+++ b/cmd/device_cfg_test.go
@@ -23,7 +23,6 @@ func TestParseDeviceFlags(t *testing.T) {
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
 				"--authorization-url", "https://example.com/authorize",
 				"--token-url", "https://example.com/token",
-				"--skip-tls-verify",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"--scope", "openid profile email",
@@ -172,6 +171,32 @@ func TestParseDeviceFlags(t *testing.T) {
 				t.Errorf("OIDCConfig got %+v, want %+v", *f.FlowConfig, tt.flowConf)
 			}
 		})
+	}
+}
+
+// --skip-tls-verify is a global-only flag, so the device subcommand must reject
+// it. The other args are valid, so the sole parse error is the undefined flag.
+func TestParseDeviceFlagsRejectsSkipTLSVerify(t *testing.T) {
+	t.Parallel()
+	args := []string{
+		"--issuer", "https://example.com",
+		"--client-id", "client-id",
+		"--client-secret", "client-secret",
+		"--scope", "openid",
+		"--skip-tls-verify",
+	}
+	runner, output, err := parseDeviceFlags(ParseInput{Name: "device", Args: args, Conf: &oidc.Config{}, Stdin: strings.NewReader("")})
+	if err == nil {
+		t.Fatal("err got nil, want unknown-flag error for --skip-tls-verify")
+	}
+	if !strings.Contains(err.Error(), "skip-tls-verify") {
+		t.Errorf("err got %v, want it to name the undefined skip-tls-verify flag", err)
+	}
+	if runner != nil {
+		t.Errorf("runner got %T, want nil on parse failure", runner)
+	}
+	if output == "" {
+		t.Error("output got empty, want usage text on parse failure")
 	}
 }
 


### PR DESCRIPTION
The device and authorization_code subcommands each registered a --skip-tls-verify flag, but the value was never read: the HTTP client is built from global flags before subcommand flags are parsed, so a subcommand-position flag was silently ignored.

Remove the dead registration from both subcommands. --skip-tls-verify stays a global flag (oidc-cli --skip-tls-verify <command>), applied once when the client is built. Passing it after a subcommand now fails with the standard "flag provided but not defined" error instead of being accepted and ignored.