### PR TITLE
chore: bump Go 1.26.4 and golangci-lint 2.12.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
-          version: "v2.11.4"
+          version: "v2.12.2"

--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ go.work
 # goreleaser dist directory
 dist/
 
-# asdf
-.tool-versions
-
 # local tmp
 tmp/
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golangci-lint 2.12.2
+golang 1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/jentz/oidc-cli
 
-go 1.26.1
+go 1.26.4
 
 require github.com/golang-jwt/jwt/v5 v5.3.1


### PR DESCRIPTION
Updates the pinned toolchain to the latest releases:

- Go 1.26.1 → 1.26.4
- golangci-lint 2.11.4 → 2.12.2

The `go.mod` directive drives the Go version for every CI workflow via `go-version-file`, so bumping it there covers build, lint, and release. The lint workflow pins golangci-lint explicitly, so that is bumped alongside it.

`.tool-versions` is now tracked so the asdf-managed toolchain is shared across contributors rather than configured per machine.

## Verification

- `go build` and `go test -race -count=1 ./...` pass on Go 1.26.4
- `golangci-lint run` reports 0 issues; `golangci-lint config verify` passes with no deprecations