### PR TITLE
feat: enable gosec security linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters:
     - copyloopvar
     - depguard
     - forbidigo
+    - gosec
     - misspell
     #- noctx
     - nolintlint
@@ -28,6 +29,9 @@ linters:
               desc: "use Go 1.13+ errors instead of pkg/errors"
             - pkg: math/rand$
               desc: "use math/rand/v2 instead"
+    gosec:
+      excludes:
+        - G104  # unhandled errors are already reported by errcheck
     revive:
       enable-all-rules: false
       rules:
@@ -54,3 +58,11 @@ linters:
         - name: unused-parameter
         - name: var-declaration
         - name: var-naming
+
+  exclusions:
+    rules:
+      # Security scanning targets production code; test fixtures routinely
+      # contain credential-like literals and helper subprocess/file calls.
+      - path: _test\.go$
+        linters:
+          - gosec

--- a/crypto/pem.go
+++ b/crypto/pem.go
@@ -9,6 +9,8 @@ import (
 )
 
 func ReadPEMBlockFromFile(filePath string) (*pem.Block, error) {
+	// #nosec G304 -- filePath is a DPoP key file the invoking user selects via
+	// a CLI flag; reading the user's own file crosses no privilege boundary.
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err

--- a/webflow/browser.go
+++ b/webflow/browser.go
@@ -54,6 +54,8 @@ func runCmd(prog string, args ...string) error {
 	if _, err := exec.LookPath(prog); err != nil {
 		return fmt.Errorf("command %s not found: %w", prog, err)
 	}
+	// #nosec G204 -- prog is a fixed per-platform literal, LookPath-validated,
+	// and the URL is a distinct argv element (no shell), so it cannot inject.
 	cmd := exec.Command(prog, args...)
 	return cmd.Run()
 }


### PR DESCRIPTION
## Summary

Enable the `gosec` linter to scan for common Go security issues, bringing
the linter configuration in line with the sibling repositories.

The two production call sites `gosec` flags are audited and safe, and now
carry justified `#nosec` directives at the call site:

- **`crypto/pem.go` (G304)** — the path is a key file the invoking user
  selects via a CLI flag, so reading it crosses no privilege boundary.
- **`webflow/browser.go` (G204)** — the program is a fixed per-platform
  literal, validated with `exec.LookPath`, and the URL is passed as a
  distinct argv element with no shell.

Configuration:

- Exclude `G104` (unhandled errors are already reported by `errcheck`).
- Disable `gosec` on `_test.go`, where fixtures routinely contain
  credential-like literals (`G101` false positives).

## Test plan

- [x] `golangci-lint run` — 0 issues, `gosec` confirmed in the active set
- [x] `go test -race -count=1 ./...` — all packages pass
