### PR TITLE
feat: enable errorlint and preserve error chains

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - bodyclose
     - copyloopvar
     - depguard
+    - errorlint
     - forbidigo
     - gosec
     - misspell

--- a/httpclient/device_authorization.go
+++ b/httpclient/device_authorization.go
@@ -51,7 +51,7 @@ func ParseDeviceAuthorizationResponse(resp *Response) (*DeviceAuthorizationRespo
 		var mapResp map[string]interface{}
 
 		if err := json.Unmarshal(resp.Body, &mapResp); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+			return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 		}
 
 		// Extract standard OAuth2 error fields if present
@@ -60,15 +60,15 @@ func ParseDeviceAuthorizationResponse(resp *Response) (*DeviceAuthorizationRespo
 			if desc, ok := mapResp["error_description"].(string); ok {
 				oauth2Err.ErrorDescription = desc
 			}
-			return nil, fmt.Errorf("%w: %v", ErrOAuthError, oauth2Err)
+			return nil, fmt.Errorf("%w: %w", ErrOAuthError, oauth2Err)
 		}
 
-		return nil, fmt.Errorf("%w: %v", ErrHTTPFailure, oauth2Err)
+		return nil, fmt.Errorf("%w: %w", ErrHTTPFailure, oauth2Err)
 	}
 
 	var deviceAuthResp DeviceAuthorizationResponse
 	if err := json.Unmarshal(resp.Body, &deviceAuthResp); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+		return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 	}
 	return &deviceAuthResp, nil
 }

--- a/httpclient/introspect.go
+++ b/httpclient/introspect.go
@@ -75,7 +75,7 @@ func ParseIntrospectionResponse(resp *Response) (map[string]interface{}, error) 
 
 	// Try to parse JSON regardless of status code
 	if err := resp.JSON(&mapResp); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+		return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 	}
 
 	if !resp.IsSuccess() {
@@ -90,7 +90,7 @@ func ParseIntrospectionResponse(resp *Response) (map[string]interface{}, error) 
 			if desc, ok := mapResp["error_description"].(string); ok {
 				oauth2Err.ErrorDescription = desc
 			}
-			return mapResp, fmt.Errorf("%w: %v", ErrOAuthError, oauth2Err)
+			return mapResp, fmt.Errorf("%w: %w", ErrOAuthError, oauth2Err)
 		}
 
 		return nil, oauth2Err

--- a/httpclient/pushed_authorization_request.go
+++ b/httpclient/pushed_authorization_request.go
@@ -53,7 +53,7 @@ func ParsePushedAuthorizationResponse(resp *Response) (*PushedAuthorizationRespo
 		var mapResp map[string]interface{}
 
 		if err := json.Unmarshal(resp.Body, &mapResp); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+			return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 		}
 
 		// Extract standard OAuth2 error fields if present
@@ -62,15 +62,15 @@ func ParsePushedAuthorizationResponse(resp *Response) (*PushedAuthorizationRespo
 			if desc, ok := mapResp["error_description"].(string); ok {
 				oauth2Err.ErrorDescription = desc
 			}
-			return nil, fmt.Errorf("%w: %v", ErrOAuthError, oauth2Err)
+			return nil, fmt.Errorf("%w: %w", ErrOAuthError, oauth2Err)
 		}
 
-		return nil, fmt.Errorf("%w: %v", ErrHTTPFailure, oauth2Err)
+		return nil, fmt.Errorf("%w: %w", ErrHTTPFailure, oauth2Err)
 	}
 
 	var parResp PushedAuthorizationResponse
 	if err := json.Unmarshal(resp.Body, &parResp); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+		return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 	}
 	return &parResp, nil
 }

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -238,7 +238,7 @@ func ParseTokenResponse(resp *Response) (map[string]interface{}, error) {
 
 	// Try to parse JSON regardless of status code
 	if err := resp.JSON(&tokenResp); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrParsingJSON, err)
+		return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)
 	}
 
 	// Check if there was an HTTP error
@@ -257,15 +257,15 @@ func ParseTokenResponse(resp *Response) (map[string]interface{}, error) {
 
 			switch errStr {
 			case "authorization_pending":
-				return tokenResp, fmt.Errorf("%w: %v", ErrAuthorizationPending, oauth2Err)
+				return tokenResp, fmt.Errorf("%w: %w", ErrAuthorizationPending, oauth2Err)
 			case "slow_down":
-				return tokenResp, fmt.Errorf("%w: %v", ErrSlowDown, oauth2Err)
+				return tokenResp, fmt.Errorf("%w: %w", ErrSlowDown, oauth2Err)
 			default:
-				return tokenResp, fmt.Errorf("%w: %v", ErrOAuthError, oauth2Err)
+				return tokenResp, fmt.Errorf("%w: %w", ErrOAuthError, oauth2Err)
 			}
 		}
 
-		return tokenResp, fmt.Errorf("%w: %v", ErrHTTPFailure, oauth2Err)
+		return tokenResp, fmt.Errorf("%w: %w", ErrHTTPFailure, oauth2Err)
 	}
 
 	// Success case with valid JSON and 2xx status code

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -400,7 +400,7 @@ func TestSleepWithContext(t *testing.T) {
 		err := sleepWithContext(ctx, 10*time.Second)
 		elapsed := time.Since(start)
 
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Errorf("Expected context.Canceled, got: %v", err)
 		}
 
@@ -418,7 +418,7 @@ func TestSleepWithContext(t *testing.T) {
 		err := sleepWithContext(ctx, 10*time.Second)
 		elapsed := time.Since(start)
 
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Errorf("Expected context.Canceled, got: %v", err)
 		}
 


### PR DESCRIPTION
## Summary

Enable the `errorlint` linter to catch error handling that breaks Go
1.13+ error wrapping, bringing the configuration in line with the
sibling repositories.

Across the `httpclient` package, several `fmt.Errorf` calls formatted
the underlying error with `%v`, which severs the chain for `errors.Is`
and `errors.As`. This switches those verbs to `%w` so both the sentinel
and the wrapped error stay inspectable (multiple `%w` is supported since
Go 1.20), and replaces `!=` error comparisons with `errors.Is` in the
token tests.

Files touched:

- `httpclient/device_authorization.go`
- `httpclient/introspect.go`
- `httpclient/pushed_authorization_request.go`
- `httpclient/token.go`
- `httpclient/token_test.go`

## Test plan

- [x] `golangci-lint run` — 0 issues, `errorlint` confirmed active
- [x] `go test -race -count=1 ./...` — all packages pass
