### PR TITLE
feat: enable contextcheck and nilerr linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,13 @@ linters:
   enable:
     - bodyclose
     - copyloopvar
+    - contextcheck
     - depguard
     - errorlint
     - forbidigo
     - gosec
     - misspell
+    - nilerr
     #- noctx
     - nolintlint
     - perfsprint

--- a/webflow/callback.go
+++ b/webflow/callback.go
@@ -119,8 +119,11 @@ func (s *CallbackServer) Start(ctx context.Context) error {
 	// Wait for context cancellation or server error
 	select {
 	case <-ctx.Done():
-		// Initiate graceful shutdown
-		return s.server.Shutdown(context.Background())
+		// The parent context is already cancelled here, so use a fresh,
+		// bounded context to let in-flight requests drain without hanging.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return s.server.Shutdown(shutdownCtx) //nolint:contextcheck // parent ctx is already cancelled; a fresh bounded context is deliberate
 	case err := <-errChan:
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil


### PR DESCRIPTION
## Summary

Enable the `contextcheck` and `nilerr` linters as correctness guards,
bringing the configuration in line with the sibling repositories.

`nilerr` reports no findings today; it guards against returning `nil`
after a non-nil error check.

`contextcheck` flagged the callback server's graceful-shutdown path,
which passed a fresh `context.Background()` to `Server.Shutdown`. The
parent context is already cancelled when that branch runs (it fires on
`ctx.Done()`), so passing the cancelled context would abort shutdown
immediately. A fresh context is therefore deliberate — this bounds it
with a timeout so shutdown cannot hang, and marks the intentional
non-inherited context with a justified `//nolint:contextcheck`.

## Test plan

- [x] `golangci-lint run` — 0 issues, `contextcheck` and `nilerr` active
- [x] `go test -race -count=1 ./...` — all packages pass
