### PR TITLE
feat: enable complexity and prealloc guardrails

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,12 +8,15 @@ linters:
     - depguard
     - errorlint
     - forbidigo
+    - gocognit
+    - gocyclo
     - gosec
     - misspell
     - nilerr
     #- noctx
     - nolintlint
     - perfsprint
+    - prealloc
     - revive
     - thelper
     - paralleltest
@@ -32,6 +35,10 @@ linters:
               desc: "use Go 1.13+ errors instead of pkg/errors"
             - pkg: math/rand$
               desc: "use math/rand/v2 instead"
+    gocognit:
+      min-complexity: 20
+    gocyclo:
+      min-complexity: 15
     gosec:
       excludes:
         - G104  # unhandled errors are already reported by errcheck
@@ -69,3 +76,9 @@ linters:
       - path: _test\.go$
         linters:
           - gosec
+      # Test functions are naturally long and branchy (table-driven setups,
+      # many subtests); complexity guardrails target production code.
+      - path: _test\.go$
+        linters:
+          - gocognit
+          - gocyclo


### PR DESCRIPTION
## Summary

Enable the `gocognit`, `gocyclo`, and `prealloc` linters, bringing the
configuration in line with the sibling repositories.

The codebase is already clean at the sibling thresholds (`gocognit`
min-complexity 20, `gocyclo` min-complexity 15), so these act as
guardrails against future complexity creep rather than flagging any
existing code. `prealloc` likewise reports no findings.

`gocognit` and `gocyclo` are excluded on `_test.go`, where table-driven
setups and many subtests make functions naturally long and branchy —
matching the sibling exclusions.

## Test plan

- [x] `golangci-lint run` — 0 issues; `gocognit`, `gocyclo`, `prealloc` active
- [x] `go test -race -count=1 ./...` — all packages pass
