### PR TITLE
feat: enable gocritic and usestdlibvars

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
     - errorlint
     - forbidigo
     - gocognit
+    - gocritic
     - gocyclo
     - gosec
     - misspell
@@ -23,6 +24,7 @@ linters:
     - tparallel
     - unconvert
     - unparam
+    - usestdlibvars
     - usetesting
     - wastedassign
 
@@ -39,6 +41,11 @@ linters:
       min-complexity: 20
     gocyclo:
       min-complexity: 15
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
     gosec:
       excludes:
         - G104  # unhandled errors are already reported by errcheck

--- a/crypto/dpop.go
+++ b/crypto/dpop.go
@@ -51,12 +51,12 @@ type DPoPProofBuilder struct {
 	errs          []error
 }
 
-func NewDPoPProof(publicKey any, privateKey any, method string, url string) (*DPoPProof, error) {
+func NewDPoPProof(publicKey, privateKey any, method, rawURL string) (*DPoPProof, error) {
 	d := NewDPoPProofBuilder().
 		PublicKey(publicKey).
 		PrivateKey(privateKey).
 		Method(method).
-		URL(url)
+		URL(rawURL)
 	return d.Build()
 }
 

--- a/httpclient/authorization_code.go
+++ b/httpclient/authorization_code.go
@@ -110,7 +110,7 @@ func CreateAuthorizationCodeRequestURL(endpoint string, values *url.Values) (str
 
 // ExecuteAuthorizationCodeRequest starts the callback server, opens the
 // authorization URL, waits for the redirect, and validates code and state.
-func (c *Client) ExecuteAuthorizationCodeRequest(ctx context.Context, endpoint string, callback string, req *AuthorizationCodeRequest) (*AuthorizationCodeResponse, error) {
+func (c *Client) ExecuteAuthorizationCodeRequest(ctx context.Context, endpoint, callback string, req *AuthorizationCodeRequest) (*AuthorizationCodeResponse, error) {
 	server, err := c.startCallbackServer(ctx, callback)
 	if err != nil {
 		return nil, err

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -103,8 +103,8 @@ func NewClient(cfg *Config) *Client {
 }
 
 // OpenURL opens url in the client's browser.
-func (c *Client) OpenURL(url string) error {
-	return c.browser.Open(url)
+func (c *Client) OpenURL(rawURL string) error {
+	return c.browser.Open(rawURL)
 }
 
 // SetSleepFunc sets a custom sleep function, primarily for testing.
@@ -122,8 +122,8 @@ func (c *Client) sleep(ctx context.Context, d time.Duration) error {
 }
 
 // Do performs an HTTP request and handles response processing
-func (c *Client) Do(ctx context.Context, method, url string, body io.Reader, headers map[string]string) (resp *Response, err error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
+func (c *Client) Do(ctx context.Context, method, rawURL string, body io.Reader, headers map[string]string) (resp *Response, err error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -158,27 +158,27 @@ func (c *Client) Do(ctx context.Context, method, url string, body io.Reader, hea
 }
 
 // Get performs an HTTP GET request
-func (c *Client) Get(ctx context.Context, url string, headers map[string]string) (*Response, error) {
-	return c.Do(ctx, http.MethodGet, url, nil, headers)
+func (c *Client) Get(ctx context.Context, rawURL string, headers map[string]string) (*Response, error) {
+	return c.Do(ctx, http.MethodGet, rawURL, nil, headers)
 }
 
 // Post performs an HTTP POST request
-func (c *Client) Post(ctx context.Context, url string, body io.Reader, headers map[string]string) (*Response, error) {
-	return c.Do(ctx, http.MethodPost, url, body, headers)
+func (c *Client) Post(ctx context.Context, rawURL string, body io.Reader, headers map[string]string) (*Response, error) {
+	return c.Do(ctx, http.MethodPost, rawURL, body, headers)
 }
 
 // PostForm sends a form-encoded POST request
-func (c *Client) PostForm(ctx context.Context, url string, formValues url.Values, headers map[string]string) (*Response, error) {
+func (c *Client) PostForm(ctx context.Context, rawURL string, formValues url.Values, headers map[string]string) (*Response, error) {
 	if headers == nil {
 		headers = make(map[string]string)
 	}
 	headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-	return c.Post(ctx, url, strings.NewReader(formValues.Encode()), headers)
+	return c.Post(ctx, rawURL, strings.NewReader(formValues.Encode()), headers)
 }
 
 // PostJSON sends a JSON POST request
-func (c *Client) PostJSON(ctx context.Context, url string, data interface{}, headers map[string]string) (*Response, error) {
+func (c *Client) PostJSON(ctx context.Context, rawURL string, data interface{}, headers map[string]string) (*Response, error) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
@@ -189,7 +189,7 @@ func (c *Client) PostJSON(ctx context.Context, url string, data interface{}, hea
 	}
 	headers["Content-Type"] = "application/json"
 
-	return c.Post(ctx, url, bytes.NewReader(jsonData), headers)
+	return c.Post(ctx, rawURL, bytes.NewReader(jsonData), headers)
 }
 
 // JSON unmarshals the response body into the provided value

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -436,7 +436,7 @@ type failingBodyCloseTransport struct{}
 func (t *failingBodyCloseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a response with a failing body closer
 	resp := &http.Response{
-		StatusCode: 200,
+		StatusCode: http.StatusOK,
 		Header:     make(http.Header),
 		Body:       &failingCloseReadCloser{data: []byte("test response")},
 		Request:    req,

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -196,7 +196,7 @@ func CreateDeviceCodeTokenRequest(clientID, clientSecret string, authMethod Auth
 }
 
 // CreateTokenExchangeRequest creates a token request for the token exchange grant
-func CreateTokenExchangeRequest(clientID, clientSecret string, authMethod AuthMethod, input TokenExchangeInput) *TokenRequest {
+func CreateTokenExchangeRequest(clientID, clientSecret string, authMethod AuthMethod, input *TokenExchangeInput) *TokenRequest {
 	params := url.Values{}
 
 	// Required parameters

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -718,7 +718,7 @@ func TestCreateTokenExchangeRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			req := CreateTokenExchangeRequest(tt.clientID, tt.clientSecret, tt.authMethod, tt.input)
+			req := CreateTokenExchangeRequest(tt.clientID, tt.clientSecret, tt.authMethod, &tt.input)
 
 			// Check basic fields
 			if req.ClientID != tt.clientID {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 // Helper function to create a logger with captured output
-func setupTestLogger(verbose bool) (*Logger, *bytes.Buffer, *bytes.Buffer) {
-	var errBuf, outBuf bytes.Buffer
-	logger := New(
+func setupTestLogger(verbose bool) (logger *Logger, errBuf, outBuf *bytes.Buffer) {
+	errBuf, outBuf = &bytes.Buffer{}, &bytes.Buffer{}
+	logger = New(
 		WithVerbose(verbose),
-		WithOutput(&outBuf, &errBuf),
+		WithOutput(outBuf, errBuf),
 	)
-	return logger, &errBuf, &outBuf
+	return logger, errBuf, outBuf
 }
 
 func TestVerboseLogging(t *testing.T) {

--- a/oidc/flow_harness_test.go
+++ b/oidc/flow_harness_test.go
@@ -82,12 +82,12 @@ type fixtureOption func(*fixtureSettings)
 
 // withRoute sets the canned response the transport returns for a specific
 // request URL, overriding the default for that endpoint only.
-func withRoute(url string, status int, body string) fixtureOption {
+func withRoute(rawURL string, status int, body string) fixtureOption {
 	return func(s *fixtureSettings) {
 		if s.routes == nil {
 			s.routes = make(map[string]cannedResponse)
 		}
-		s.routes[url] = cannedResponse{status: status, body: body}
+		s.routes[rawURL] = cannedResponse{status: status, body: body}
 	}
 }
 

--- a/oidc/token_exchange.go
+++ b/oidc/token_exchange.go
@@ -40,7 +40,7 @@ func (c *TokenExchangeFlow) createTokenRequest() *httpclient.TokenRequest {
 		c.Config.OIDC.ClientID,
 		c.Config.OIDC.ClientSecret,
 		c.Config.OIDC.AuthMethod,
-		input)
+		&input)
 
 	return req
 }

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -157,7 +157,7 @@ func TestCallbackServerStartWithInjectedListener(t *testing.T) {
 	callbackURL := fmt.Sprintf("http://%s/callback?code=abc123&state=xyz", ln.Addr().String())
 	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer reqCancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, callbackURL, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, callbackURL, http.NoBody)
 	if err != nil {
 		t.Fatalf("failed to build request: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestCallbackServerHandleCallback(t *testing.T) {
 			}
 
 			w := httptest.NewRecorder()
-			r := httptest.NewRequest("GET", "/callback?"+tt.query, nil)
+			r := httptest.NewRequest(http.MethodGet, "/callback?"+tt.query, http.NoBody)
 			s.handleCallback(w, r)
 
 			if w.Code != tt.wantStatus {


### PR DESCRIPTION
## Summary

Enable the `gocritic` (diagnostic, performance, and style checks) and
`usestdlibvars` linters, bringing the configuration in line with the
sibling repositories.

Fixes for the findings:

- **importShadow** — renamed `url` parameters that shadowed the
  `net/url` import across the `httpclient` client methods, the DPoP
  proof builder, and a test helper.
- **paramTypeCombine** — combined consecutive same-type parameters into
  a single declaration.
- **hugeParam** — `CreateTokenExchangeRequest` now takes
  `*TokenExchangeInput`, avoiding a 144-byte struct copy on every
  token-exchange request.
- **usestdlibvars / httpNoBody / unnamedResult (tests)** — used
  `http.NoBody`, `http.MethodGet`, and `http.StatusOK` instead of `nil`
  and bare literals, and named the flagged return values.

## Test plan

- [x] `golangci-lint run` — 0 issues; `gocritic` and `usestdlibvars` active
- [x] `go test -race -count=1 ./...` — all packages pass
