### PR TITLE
feat: expand the revive ruleset to match siblings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,29 +52,74 @@ linters:
     revive:
       enable-all-rules: false
       rules:
+        - name: argument-limit
+          arguments: [6]
+        - name: atomic
         - name: blank-imports
+        - name: bool-literal-in-expr
+        - name: comment-spacings
+        - name: confusing-naming
+        - name: confusing-results
         - name: context-as-argument
         - name: context-keys-type
-        - name: comment-spacings
+        - name: defer
         - name: dot-imports
+        - name: duplicated-imports
+        - name: early-return
         - name: empty-block
         - name: empty-lines
+        - name: enforce-map-style
+          arguments: [make]
+        - name: enforce-slice-style
+          arguments: [make]
         - name: error-naming
         - name: error-return
         - name: error-strings
         - name: errorf
+        - name: flag-parameter
+        - name: function-length
+          arguments: [60, 0]
+        - name: get-return
+        - name: identical-branches
+        - name: if-return
+        - name: import-shadowing
         - name: increment-decrement
         - name: indent-error-flow
+        - name: modifies-parameter
+        - name: modifies-value-receiver
         - name: range
+        - name: range-val-address
+        - name: range-val-in-closure
         - name: receiver-naming
         - name: redefines-builtin-id
+        - name: redundant-import-alias
+        - name: string-format
+        - name: string-of-int
+        - name: struct-tag
         - name: superfluous-else
+        - name: time-equal
         - name: time-naming
+        - name: unchecked-type-assertion
+        - name: unexported-naming
         - name: unexported-return
+        - name: unhandled-error
+          arguments:
+            # Writes to stdout/stderr and in-memory buffers are handled at the
+            # call-site return, not inline, so their errors may be ignored.
+            - fmt\.Print.*
+            - fmt\.Fprint.*
+            - bytes\.Buffer\.Write.*
+            - strings\.Builder\.Write.*
+            - io\.WriteString
+        - name: unnecessary-stmt
         - name: unreachable-code
         - name: unused-parameter
+        - name: unused-receiver
+        - name: use-any
+        - name: useless-break
         - name: var-declaration
         - name: var-naming
+        - name: waitgroup-by-value
 
   exclusions:
     rules:
@@ -89,3 +134,7 @@ linters:
         linters:
           - gocognit
           - gocyclo
+      # Length- and complexity-oriented checks target production code;
+      # table-driven test fixtures make functions naturally long.
+      - path: _test\.go$
+        text: function-length|cognitive-complexity|cyclomatic|hugeParam|rangeValCopy

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -11,7 +11,7 @@ import (
 
 type CustomArgsFlag []string
 
-func (c *CustomArgsFlag) String() string {
+func (*CustomArgsFlag) String() string {
 	return ""
 }
 

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -32,7 +32,7 @@ func TestCLI_HelpFlag(t *testing.T) { //nolint:paralleltest // mutates global fl
 func TestCLI_NoArgs(t *testing.T) { //nolint:paralleltest // mutates global flag.CommandLine
 	resetFlags()
 	var out bytes.Buffer
-	code := CLI([]string{}, log.WithOutput(&out, &out))
+	code := CLI(make([]string, 0), log.WithOutput(&out, &out))
 	if code != ExitError {
 		t.Errorf("expected ExitError, got %d", code)
 	}

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -36,7 +36,7 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 					ClientSecret:      "client-secret",
 				},
 			},
-			remainingArgs: []string{},
+			remainingArgs: make([]string, 0),
 		},
 		{
 			name: "only issuer",
@@ -52,7 +52,7 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 					ClientSecret: "client-secret",
 				},
 			},
-			remainingArgs: []string{},
+			remainingArgs: make([]string, 0),
 		},
 		{
 			name: "verbose flag",
@@ -69,7 +69,7 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 					ClientSecret: "client-secret",
 				},
 			},
-			remainingArgs: []string{},
+			remainingArgs: make([]string, 0),
 		},
 		{
 			name: "flags after non-flag argument",

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -301,7 +301,7 @@ func TestParseIntrospectFlagsCustomArgs(t *testing.T) {
 	if f.FlowConfig.CustomArgs == nil {
 		t.Fatalf("CustomArgs is nil, want non-nil")
 	}
-	argsMap := map[string]string{}
+	argsMap := make(map[string]string)
 	for k, v := range *f.FlowConfig.CustomArgs {
 		argsMap[k] = v
 	}

--- a/crypto/cryptotest/dpop.go
+++ b/crypto/cryptotest/dpop.go
@@ -66,7 +66,11 @@ func CheckDPoPProof(proof string, pub crypto.PublicKey, wantHTM, wantHTU string)
 		return fmt.Errorf("parsing proof: %w", err)
 	}
 
-	if typ, _ := token.Header["typ"].(string); typ != "dpop+jwt" {
+	typ, ok := token.Header["typ"].(string)
+	if !ok {
+		return fmt.Errorf("header typ = %v, want a \"dpop+jwt\" string", token.Header["typ"])
+	}
+	if typ != "dpop+jwt" {
 		return fmt.Errorf("header typ = %q, want \"dpop+jwt\"", typ)
 	}
 
@@ -78,13 +82,21 @@ func CheckDPoPProof(proof string, pub crypto.PublicKey, wantHTM, wantHTU string)
 	if !ok {
 		return fmt.Errorf("claims type = %T, want jwt.MapClaims", token.Claims)
 	}
-	if htm, _ := claims["htm"].(string); htm != wantHTM {
+	htm, ok := claims["htm"].(string)
+	if !ok {
+		return fmt.Errorf("htm claim = %v, want a %q string", claims["htm"], wantHTM)
+	}
+	if htm != wantHTM {
 		return fmt.Errorf("htm claim = %q, want %q", htm, wantHTM)
 	}
-	if htu, _ := claims["htu"].(string); htu != wantHTU {
+	htu, ok := claims["htu"].(string)
+	if !ok {
+		return fmt.Errorf("htu claim = %v, want a %q string", claims["htu"], wantHTU)
+	}
+	if htu != wantHTU {
 		return fmt.Errorf("htu claim = %q, want %q", htu, wantHTU)
 	}
-	if jti, _ := claims["jti"].(string); jti == "" {
+	if jti, ok := claims["jti"].(string); !ok || jti == "" {
 		return errors.New("jti claim is missing or empty")
 	}
 	return checkRecentIAT(claims)
@@ -111,7 +123,10 @@ func publicKeyFromJWK(raw any) (crypto.PublicKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("jwk header is missing or not an object (got %T)", raw)
 	}
-	kty, _ := jwk["kty"].(string)
+	kty, ok := jwk["kty"].(string)
+	if !ok {
+		return nil, fmt.Errorf("jwk kty is missing or not a string (got %T)", jwk["kty"])
+	}
 	switch kty {
 	case "EC":
 		return ecdsaKeyFromJWK(jwk)
@@ -125,7 +140,10 @@ func publicKeyFromJWK(raw any) (crypto.PublicKey, error) {
 }
 
 func ecdsaKeyFromJWK(jwk map[string]any) (crypto.PublicKey, error) {
-	crv, _ := jwk["crv"].(string)
+	crv, ok := jwk["crv"].(string)
+	if !ok {
+		return nil, fmt.Errorf("jwk crv is missing or not a string (got %T)", jwk["crv"])
+	}
 	var curve elliptic.Curve
 	switch crv {
 	case "P-256":

--- a/crypto/dpop_test.go
+++ b/crypto/dpop_test.go
@@ -288,7 +288,10 @@ func TestConstructJWT(t *testing.T) {
 			if got.Claims == nil {
 				t.Errorf("token.Claims = %v, want %v", got.Claims, "not nil")
 			}
-			claims := got.Claims.(jwt.MapClaims)
+			claims, ok := got.Claims.(jwt.MapClaims)
+			if !ok {
+				t.Fatalf("token.Claims type = %T, want jwt.MapClaims", got.Claims)
+			}
 			if claims["jti"] != tt.dpopProofBuilder.jti {
 				t.Errorf("claims[\"jti\"] = %v, want %v", claims["jti"], tt.dpopProofBuilder.jti)
 			}

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -178,7 +178,7 @@ func (c *Client) PostForm(ctx context.Context, rawURL string, formValues url.Val
 }
 
 // PostJSON sends a JSON POST request
-func (c *Client) PostJSON(ctx context.Context, rawURL string, data interface{}, headers map[string]string) (*Response, error) {
+func (c *Client) PostJSON(ctx context.Context, rawURL string, data any, headers map[string]string) (*Response, error) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
@@ -193,7 +193,7 @@ func (c *Client) PostJSON(ctx context.Context, rawURL string, data interface{}, 
 }
 
 // JSON unmarshals the response body into the provided value
-func (r *Response) JSON(v interface{}) error {
+func (r *Response) JSON(v any) error {
 	return json.Unmarshal(r.Body, v)
 }
 

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -215,12 +215,12 @@ func TestPostJSON(t *testing.T) {
 			t.Errorf("Expected JSON content type, got %s", contentType)
 		}
 
-		var data map[string]interface{}
+		var data map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&data)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"received": data["message"],
 			"status":   "ok",
 		}
@@ -229,7 +229,7 @@ func TestPostJSON(t *testing.T) {
 	defer ts.Close()
 
 	client := NewClient(nil)
-	requestData := map[string]interface{}{
+	requestData := map[string]any{
 		"message": "hello world",
 		"count":   42,
 	}
@@ -246,13 +246,16 @@ func TestPostJSON(t *testing.T) {
 		t.Errorf("got status code %d, want %d", got, want)
 	}
 
-	var responseData map[string]interface{}
+	var responseData map[string]any
 	err = resp.JSON(&responseData)
 	if err != nil {
 		t.Fatalf("Failed to parse JSON response: %v", err)
 	}
 
-	gotMessage := responseData["received"].(string)
+	gotMessage, ok := responseData["received"].(string)
+	if !ok {
+		t.Fatalf("responseData[\"received\"] type = %T, want string", responseData["received"])
+	}
 	wantMessage := "hello world"
 	if gotMessage != wantMessage {
 		t.Errorf("got message %q, want %q", gotMessage, wantMessage)
@@ -277,7 +280,7 @@ func TestResponseMethods(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		response := map[string]interface{}{
+		response := map[string]any{
 			"message": "test response",
 			"code":    200,
 		}
@@ -298,19 +301,26 @@ func TestResponseMethods(t *testing.T) {
 	}
 
 	// Test JSON method
-	var data map[string]interface{}
+	var data map[string]any
 	err = resp.JSON(&data)
 	if err != nil {
 		t.Fatalf("JSON() method failed: %v", err)
 	}
 
-	gotMessage := data["message"].(string)
+	gotMessage, ok := data["message"].(string)
+	if !ok {
+		t.Fatalf("data[\"message\"] type = %T, want string", data["message"])
+	}
 	wantMessage := "test response"
 	if gotMessage != wantMessage {
 		t.Errorf("got message %q, want %q", gotMessage, wantMessage)
 	}
 
-	gotCode := int(data["code"].(float64))
+	gotCodeFloat, ok := data["code"].(float64)
+	if !ok {
+		t.Fatalf("data[\"code\"] type = %T, want float64", data["code"])
+	}
+	gotCode := int(gotCodeFloat)
 	wantCode := 200
 	if gotCode != wantCode {
 		t.Errorf("got code %d, want %d", gotCode, wantCode)
@@ -331,7 +341,7 @@ func TestResponseJSON_InvalidJSON(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	err = resp.JSON(&data)
 	if err == nil {
 		t.Error("Expected JSON unmarshal error, got nil")
@@ -433,7 +443,7 @@ func TestDo_ResponseBodyCloseError(t *testing.T) {
 // failingBodyCloseTransport is a custom transport that returns responses with bodies that fail to close
 type failingBodyCloseTransport struct{}
 
-func (t *failingBodyCloseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (*failingBodyCloseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a response with a failing body closer
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -459,6 +469,6 @@ func (f *failingCloseReadCloser) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
-func (f *failingCloseReadCloser) Close() error {
+func (*failingCloseReadCloser) Close() error {
 	return errors.New("simulated close error")
 }

--- a/httpclient/device_authorization.go
+++ b/httpclient/device_authorization.go
@@ -48,7 +48,7 @@ func ParseDeviceAuthorizationResponse(resp *Response) (*DeviceAuthorizationRespo
 			StatusCode: resp.StatusCode,
 			RawBody:    resp.String(),
 		}
-		var mapResp map[string]interface{}
+		var mapResp map[string]any
 
 		if err := json.Unmarshal(resp.Body, &mapResp); err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)

--- a/httpclient/introspect.go
+++ b/httpclient/introspect.go
@@ -70,8 +70,8 @@ func (c *Client) ExecuteIntrospectionRequest(ctx context.Context, endpoint strin
 }
 
 // ParseIntrospectionResponse parses the introspection response into a map
-func ParseIntrospectionResponse(resp *Response) (map[string]interface{}, error) {
-	var mapResp map[string]interface{}
+func ParseIntrospectionResponse(resp *Response) (map[string]any, error) {
+	var mapResp map[string]any
 
 	// Try to parse JSON regardless of status code
 	if err := resp.JSON(&mapResp); err != nil {

--- a/httpclient/pushed_authorization_request.go
+++ b/httpclient/pushed_authorization_request.go
@@ -50,7 +50,7 @@ func ParsePushedAuthorizationResponse(resp *Response) (*PushedAuthorizationRespo
 			StatusCode: resp.StatusCode,
 			RawBody:    resp.String(),
 		}
-		var mapResp map[string]interface{}
+		var mapResp map[string]any
 
 		if err := json.Unmarshal(resp.Body, &mapResp); err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrParsingJSON, err)

--- a/httpclient/token.go
+++ b/httpclient/token.go
@@ -25,7 +25,7 @@ func sleepWithContext(ctx context.Context, d time.Duration) error {
 
 // DPoPProofFunc generates a DPoP proof for the given HTTP method and URL.
 // It is called once per request, ensuring each token request carries a fresh proof.
-type DPoPProofFunc func(method, url string) (string, error)
+type DPoPProofFunc func(method, requestURL string) (string, error)
 
 // TokenRequest represents an OAuth2 token request
 type TokenRequest struct {
@@ -233,8 +233,8 @@ func CreateTokenExchangeRequest(clientID, clientSecret string, authMethod AuthMe
 }
 
 // ParseTokenResponse parses the standard OAuth2 token response
-func ParseTokenResponse(resp *Response) (map[string]interface{}, error) {
-	var tokenResp map[string]interface{}
+func ParseTokenResponse(resp *Response) (map[string]any, error) {
+	var tokenResp map[string]any
 
 	// Try to parse JSON regardless of status code
 	if err := resp.JSON(&tokenResp); err != nil {

--- a/httpclient/token_test.go
+++ b/httpclient/token_test.go
@@ -129,9 +129,9 @@ func TestExecuteTokenRequest_DPoPFunctionCalledWithMethodAndURL(t *testing.T) {
 		ClientID:     "test-client",
 		ClientSecret: "test-secret",
 		AuthMethod:   AuthMethodPost,
-		DPoP: func(method, url string) (string, error) {
+		DPoP: func(method, requestURL string) (string, error) {
 			gotMethod = method
-			gotURL = url
+			gotURL = requestURL
 			return "proof-123", nil
 		},
 	}
@@ -200,7 +200,7 @@ func TestExecutePollingTokenRequest(t *testing.T) {
 	}{
 		{
 			name:         "immediate success",
-			intervals:    []int{},
+			intervals:    make([]int, 0),
 			wantAttempts: 1,
 		},
 		{
@@ -592,7 +592,7 @@ func TestCreateClientCredentialsRequest(t *testing.T) {
 			clientSecret: "secret012",
 			authMethod:   AuthMethodPost,
 			scope:        "",
-			wantParams:   map[string]string{},
+			wantParams:   make(map[string]string),
 		},
 	}
 
@@ -760,14 +760,14 @@ func TestParseTokenResponse(t *testing.T) {
 		body       string
 		wantErr    bool
 		wantErrMsg string
-		wantData   map[string]interface{}
+		wantData   map[string]any
 	}{
 		{
 			name:       "successful response",
 			statusCode: 200,
 			body:       `{"access_token":"token123","token_type":"Bearer","expires_in":3600}`,
 			wantErr:    false,
-			wantData: map[string]interface{}{
+			wantData: map[string]any{
 				"access_token": "token123",
 				"token_type":   "Bearer",
 				"expires_in":   float64(3600),

--- a/log/log.go
+++ b/log/log.go
@@ -74,36 +74,36 @@ func (l *Logger) SetVerbose(verbose bool) {
 }
 
 // Printf formats and writes a message to the error output (only in verbose mode).
-func (l *Logger) Printf(format string, a ...interface{}) {
+func (l *Logger) Printf(format string, a ...any) {
 	if l.verbose {
 		_, _ = fmt.Fprintf(l.errOut, format, a...)
 	}
 }
 
 // Println writes a message to the error output (only in verbose mode).
-func (l *Logger) Println(a ...interface{}) {
+func (l *Logger) Println(a ...any) {
 	if l.verbose {
 		_, _ = fmt.Fprintln(l.errOut, a...)
 	}
 }
 
 // Errorf writes a formatted error message to the error output (always).
-func (l *Logger) Errorf(format string, a ...interface{}) {
+func (l *Logger) Errorf(format string, a ...any) {
 	_, _ = fmt.Fprintf(l.errOut, format, a...)
 }
 
 // Errorln writes an error message to the error output (always).
-func (l *Logger) Errorln(a ...interface{}) {
+func (l *Logger) Errorln(a ...any) {
 	_, _ = fmt.Fprintln(l.errOut, a...)
 }
 
 // Outputf writes formatted output to stdout (always).
-func (l *Logger) Outputf(format string, args ...interface{}) {
+func (l *Logger) Outputf(format string, args ...any) {
 	_, _ = fmt.Fprintf(l.stdOut, format, args...)
 }
 
 // Outputln writes line output to stdout (always).
-func (l *Logger) Outputln(args ...interface{}) {
+func (l *Logger) Outputln(args ...any) {
 	_, _ = fmt.Fprintln(l.stdOut, args...)
 }
 
@@ -119,14 +119,14 @@ func (l *Logger) OutputJSON(v any) error {
 }
 
 // Verbosef writes formatted output to stdout (only in verbose mode)
-func (l *Logger) Verbosef(format string, args ...interface{}) {
+func (l *Logger) Verbosef(format string, args ...any) {
 	if l.verbose {
 		_, _ = fmt.Fprintf(l.stdOut, format, args...)
 	}
 }
 
 // Verboseln writes line output to stdout (only in verbose mode)
-func (l *Logger) Verboseln(args ...interface{}) {
+func (l *Logger) Verboseln(args ...any) {
 	if l.verbose {
 		_, _ = fmt.Fprintln(l.stdOut, args...)
 	}

--- a/oidc/authorization_code.go
+++ b/oidc/authorization_code.go
@@ -82,7 +82,7 @@ func (c *AuthorizationCodeFlow) executeAuthCodeRequest(ctx context.Context, req 
 	return resp, nil
 }
 
-func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, codeVerifier string, dpop httpclient.DPoPProofFunc) (map[string]interface{}, error) {
+func (c *AuthorizationCodeFlow) executeTokenRequest(ctx context.Context, code, codeVerifier string, dpop httpclient.DPoPProofFunc) (map[string]any, error) {
 	tokenRequest := httpclient.CreateAuthCodeTokenRequest(
 		c.Config.OIDC.ClientID,
 		c.Config.OIDC.ClientSecret,

--- a/oidc/oidc_config.go
+++ b/oidc/oidc_config.go
@@ -108,7 +108,7 @@ func (o *OIDCConfig) DiscoverEndpoints(ctx context.Context, client *httpclient.C
 // verifier when not. A client with no secret cannot authenticate at the token
 // endpoint, so PKCE secures a public client and the auth method falls back to
 // none.
-func (o *OIDCConfig) setupPKCE(enabled bool) (string, error) {
+func (o *OIDCConfig) setupPKCE(enabled bool) (string, error) { //nolint:revive // flag-parameter: PKCE is an optional per-flow toggle, so a bool cleanly gates verifier generation.
 	if !enabled {
 		return "", nil
 	}

--- a/webflow/callback_test.go
+++ b/webflow/callback_test.go
@@ -46,7 +46,7 @@ func (m *mockListener) Close() error {
 	return nil
 }
 
-func (m *mockListener) Addr() net.Addr {
+func (*mockListener) Addr() net.Addr {
 	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}
 }
 


### PR DESCRIPTION
## Summary

Expand the `revive` configuration to the full ruleset used by the
sibling repositories, so the three repos share one lint baseline. This
adds a range of correctness and style rules on top of the existing set
(for example `unchecked-type-assertion`, `use-any`,
`enforce-slice-style`, `enforce-map-style`, `unused-receiver`,
`import-shadowing`, and `flag-parameter`).

Fixes for the resulting findings:

- **use-any** — replaced `interface{}` with `any` across `log`,
  `httpclient`, `oidc`, and their tests.
- **unchecked-type-assertion** — guarded assertions with the comma-ok
  form, failing the test (or returning a descriptive error in the
  crypto test helper) on mismatch.
- **enforce-slice-style / enforce-map-style** — used `make()` for slice
  and map construction.
- **unused-receiver** — omitted unused method receiver names (which
  also satisfies `receiver-naming`).
- **import-shadowing** — renamed `url` parameters that shadowed the
  `net/url` import in the DPoP proof-function signatures.
- **flag-parameter** — the single finding, `setupPKCE`'s `enabled`
  toggle, carries a justified `//nolint:revive`; it is an optional
  per-flow feature gate sourced from config.

Length- and complexity-oriented checks are excluded on `_test.go`,
where table-driven fixtures make functions naturally long — matching
the sibling exclusions.

## Test plan

- [x] `golangci-lint run` — 0 issues, expanded `revive` ruleset active
- [x] `go test -race -count=1 ./...` — all packages pass
