### PR TITLE
feat: harmonize Makefile with sibling conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,59 @@
 # Makefile for oidc-cli
 
-.PHONY: help test build lint clean coverage
+BINARY := oidc-cli
+PKG := ./...
+COVERAGE_OUT := coverage.out
+COVERAGE_HTML := coverage.html
 
-BINARY=oidc-cli
+.DEFAULT_GOAL := help
 
-help:
-	@echo "\nUsage: make <target>\n"
-	@echo "Targets:"
-	@echo "  help     Show this help message"
-	@echo "  test     Run all Go tests (go test -race -count=1 ./...)"
-	@echo "  build    Build the oidc-cli binary (go build -v -o $(BINARY))"
-	@echo "  lint     Run golangci-lint (uses .golangci.yaml config)"
-	@echo "  clean    Remove built binaries and test cache"
-	@echo "  coverage  Run tests with coverage and generate coverage.out"
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
-# Run all tests
+.PHONY: build
+build: ## Build the oidc-cli binary
+	go build -v -o $(BINARY) .
 
-test:
-	go test -race -count=1 ./...
+.PHONY: test
+test: ## Run tests
+	go test $(PKG)
 
-# Build the binary
+.PHONY: test-race
+test-race: ## Run tests with the race detector
+	go test -race -count=1 $(PKG)
 
-build:
-	go build -v -o $(BINARY)
-
-# Lint the codebase
-
-lint:
+.PHONY: lint
+lint: ## Run golangci-lint
 	golangci-lint run
 
-# Clean up build artifacts and test cache
+.PHONY: tidy
+tidy: ## Tidy go.mod and go.sum
+	go mod tidy
 
-clean:
-	rm -f $(BINARY)
+.PHONY: coverage
+coverage: ## Run tests with coverage; print total % and write an HTML report
+	go test -race -covermode=atomic -coverprofile=$(COVERAGE_OUT) $(PKG)
+	@go tool cover -func=$(COVERAGE_OUT) | tail -n 1
+	@go tool cover -html=$(COVERAGE_OUT) -o $(COVERAGE_HTML)
+
+.PHONY: ci
+ci: tidy lint coverage ## Run the full local gate (tidy + lint + coverage)
+	@echo "ci: ok"
+
+.PHONY: clean
+clean: ## Remove build and coverage artifacts and the test cache
+	rm -f $(BINARY) $(COVERAGE_OUT) $(COVERAGE_HTML)
 	go clean -testcache
 
-# Run tests with coverage
+.PHONY: lint-clean
+lint-clean: ## Purge the golangci-lint cache
+	golangci-lint cache clean
 
-coverage:
-	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+.PHONY: realclean
+realclean: clean lint-clean ## Run clean, purge the lint cache, and purge the Go build cache
+	go clean -cache
+
+# fmt / fmt-check (golangci-lint fmt / --diff) are intentionally omitted for
+# now: they require a formatters (gofumpt/goimports) block in .golangci.yaml,
+# which is tracked as separate work. Add them once that configuration lands.


### PR DESCRIPTION
## Summary

Harmonize the Makefile with the sibling repositories (using `rdstun`,
the closest analog, as the primary reference), adopting a
CLI-appropriate subset of targets and conventions.

Added / changed:

- **New targets** — `tidy`, `test-race` (split from a plain `test`),
  `ci` (an aggregate `tidy + lint + coverage` gate so local runs match
  CI), `lint-clean`, and `realclean`.
- **Richer `coverage`** — prints the total coverage percentage to
  stdout and writes an HTML report alongside `coverage.out`.
- **Self-documenting `help`** — generated from `## ` target comments
  (so it cannot drift from the actual targets) and set as the default
  goal.
- **DRY variables** — `PKG`, `COVERAGE_OUT`, `COVERAGE_HTML` alongside
  the existing `BINARY`.

Deliberately omitted:

- `fmt` / `fmt-check` (`golangci-lint fmt`) — these need a formatters
  (gofumpt/goimports) block in `.golangci.yaml`, tracked as separate
  work; they will be added when that lands.
- `pos-versions`' service-specific targets (docker/compose, terraform,
  DynamoDB, `generate`, e2e) — not applicable to this CLI.

`coverage.html` is added to `.gitignore`.

## Test plan

- [x] `make ci` passes locally (tidy + lint + coverage)
- [x] `make help` lists all targets from their comments
- [x] `make build` produces the `oidc-cli` binary
