### PR TITLE
test: add CLI acceptance harness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,20 @@ jobs:
           args: build --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Run CLI acceptance tests
+        run: make acceptance

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINARY := oidc-cli
 PKG := ./...
 COVERAGE_OUT := coverage.out
 COVERAGE_HTML := coverage.html
+ACCEPTANCE_BIN := tmp/oidc-cli-acceptance
 
 .DEFAULT_GOAL := help
 
@@ -37,13 +38,19 @@ coverage: ## Run tests with coverage; print total % and write an HTML report
 	@go tool cover -func=$(COVERAGE_OUT) | tail -n 1
 	@go tool cover -html=$(COVERAGE_OUT) -o $(COVERAGE_HTML)
 
+.PHONY: acceptance
+acceptance: ## Run CLI acceptance tests
+	@mkdir -p $(dir $(ACCEPTANCE_BIN))
+	go build -v -o $(ACCEPTANCE_BIN) .
+	OIDC_CLI_BIN=$$(pwd)/$(ACCEPTANCE_BIN) go test -tags=acceptance ./test/acceptance
+
 .PHONY: ci
-ci: tidy lint coverage ## Run the full local gate (tidy + lint + coverage)
+ci: tidy lint coverage acceptance ## Run the full local gate (tidy + lint + coverage + acceptance)
 	@echo "ci: ok"
 
 .PHONY: clean
 clean: ## Remove build and coverage artifacts and the test cache
-	rm -f $(BINARY) $(COVERAGE_OUT) $(COVERAGE_HTML)
+	rm -f $(BINARY) $(ACCEPTANCE_BIN) $(COVERAGE_OUT) $(COVERAGE_HTML)
 	go clean -testcache
 
 .PHONY: lint-clean

--- a/test/acceptance/cli_test.go
+++ b/test/acceptance/cli_test.go
@@ -1,0 +1,41 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunsBinaryAndCapturesSuccessfulOutput(t *testing.T) {
+	result := Run(t, "version")
+
+	if got, want := result.ExitCode, 0; got != want {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", got, want, result.Stdout, result.Stderr)
+	}
+	if !strings.HasPrefix(result.Stdout, "oidc-cli version: ") {
+		t.Fatalf("stdout = %q, want oidc-cli version line", result.Stdout)
+	}
+	if result.Stderr != "" {
+		t.Fatalf("stderr = %q, want empty stderr", result.Stderr)
+	}
+}
+
+func TestRunsBinaryAndCapturesFailedOutput(t *testing.T) {
+	result := Run(t, "not-a-command")
+
+	if got, want := result.ExitCode, 1; got != want {
+		t.Fatalf("exit code = %d, want %d\nstdout:\n%s\nstderr:\n%s", got, want, result.Stdout, result.Stderr)
+	}
+	if got, want := result.Stdout, ""; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	for _, want := range []string{`error: command "not-a-command" not found`, "See 'oidc-cli --help' for usage."} {
+		if !strings.Contains(result.Stderr, want) {
+			t.Fatalf("stderr = %q, want it to contain %q", result.Stderr, want)
+		}
+	}
+	if strings.Contains(result.Stderr, "client_credentials") {
+		t.Fatalf("stderr = %q, should not contain unrelated command help", result.Stderr)
+	}
+}

--- a/test/acceptance/harness.go
+++ b/test/acceptance/harness.go
@@ -1,0 +1,110 @@
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+const binaryEnv = "OIDC_CLI_BIN"
+
+type statFunc func(string) (os.FileInfo, error)
+
+// Result captures the observable outcome of running oidc-cli as a black-box
+// command-line program.
+type Result struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+}
+
+// JSON parses stdout as a JSON object for commands that emit token responses.
+func (r Result) JSON(tb testing.TB) map[string]any {
+	tb.Helper()
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(r.Stdout), &out); err != nil {
+		tb.Fatalf("stdout is not a JSON object: %v\nstdout:\n%s\nstderr:\n%s", err, r.Stdout, r.Stderr)
+	}
+	return out
+}
+
+// RequireBinary returns the compiled oidc-cli binary path from OIDC_CLI_BIN.
+// Missing or invalid configuration is a harness failure, not a skipped test.
+func RequireBinary(tb testing.TB) string {
+	tb.Helper()
+
+	path, err := resolveBinary(os.Getenv, os.Stat)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+// Run executes the compiled oidc-cli binary with args and captures its exit
+// status, stdout, and stderr.
+func Run(tb testing.TB, args ...string) Result {
+	tb.Helper()
+	return RunWithContext(context.Background(), tb, args...)
+}
+
+// RunWithContext executes oidc-cli with args and captures its observable
+// process result.
+func RunWithContext(ctx context.Context, tb testing.TB, args ...string) Result {
+	tb.Helper()
+
+	bin := RequireBinary(tb)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...) // #nosec G204 -- acceptance tests intentionally execute the configured oidc-cli binary.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		tb.Fatalf("oidc-cli command timed out: %v", ctx.Err())
+	}
+
+	result := Result{
+		ExitCode: 0,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			result.ExitCode = exitErr.ExitCode()
+			return result
+		}
+		tb.Fatalf("failed to run oidc-cli: %v", err)
+	}
+	return result
+}
+
+func resolveBinary(getenv func(string) string, stat statFunc) (string, error) {
+	path := getenv(binaryEnv)
+	if path == "" {
+		return "", fmt.Errorf("%s must point to the compiled oidc-cli binary", binaryEnv)
+	}
+
+	info, err := stat(path)
+	if err != nil {
+		return "", fmt.Errorf("%s must point to the compiled oidc-cli binary: %w", binaryEnv, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s must point to the compiled oidc-cli binary, got directory %q", binaryEnv, path)
+	}
+	if info.Mode()&0o111 == 0 {
+		return "", fmt.Errorf("%s must point to an executable oidc-cli binary, got %q", binaryEnv, path)
+	}
+
+	return path, nil
+}

--- a/test/acceptance/harness.go
+++ b/test/acceptance/harness.go
@@ -1,15 +1,10 @@
 package acceptance
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
-	"time"
 )
 
 const binaryEnv = "OIDC_CLI_BIN"
@@ -33,60 +28,6 @@ func (r Result) JSON(tb testing.TB) map[string]any {
 		tb.Fatalf("stdout is not a JSON object: %v\nstdout:\n%s\nstderr:\n%s", err, r.Stdout, r.Stderr)
 	}
 	return out
-}
-
-// RequireBinary returns the compiled oidc-cli binary path from OIDC_CLI_BIN.
-// Missing or invalid configuration is a harness failure, not a skipped test.
-func RequireBinary(tb testing.TB) string {
-	tb.Helper()
-
-	path, err := resolveBinary(os.Getenv, os.Stat)
-	if err != nil {
-		tb.Fatal(err)
-	}
-	return path
-}
-
-// Run executes the compiled oidc-cli binary with args and captures its exit
-// status, stdout, and stderr.
-func Run(tb testing.TB, args ...string) Result {
-	tb.Helper()
-	return RunWithContext(context.Background(), tb, args...)
-}
-
-// RunWithContext executes oidc-cli with args and captures its observable
-// process result.
-func RunWithContext(ctx context.Context, tb testing.TB, args ...string) Result {
-	tb.Helper()
-
-	bin := RequireBinary(tb)
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, bin, args...) // #nosec G204 -- acceptance tests intentionally execute the configured oidc-cli binary.
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	if ctx.Err() != nil {
-		tb.Fatalf("oidc-cli command timed out: %v", ctx.Err())
-	}
-
-	result := Result{
-		ExitCode: 0,
-		Stdout:   stdout.String(),
-		Stderr:   stderr.String(),
-	}
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			result.ExitCode = exitErr.ExitCode()
-			return result
-		}
-		tb.Fatalf("failed to run oidc-cli: %v", err)
-	}
-	return result
 }
 
 func resolveBinary(getenv func(string) string, stat statFunc) (string, error) {

--- a/test/acceptance/harness_test.go
+++ b/test/acceptance/harness_test.go
@@ -1,0 +1,101 @@
+package acceptance
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeFileInfo struct {
+	name  string
+	mode  os.FileMode
+	isDir bool
+}
+
+func (f fakeFileInfo) Name() string      { return f.name }
+func (fakeFileInfo) Size() int64         { return 1 }
+func (f fakeFileInfo) Mode() os.FileMode { return f.mode }
+func (fakeFileInfo) ModTime() time.Time  { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool       { return f.isDir }
+func (fakeFileInfo) Sys() any            { return nil }
+
+func TestResolveBinaryRequiresOIDCCLIBin(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveBinary(func(string) string { return "" }, func(string) (os.FileInfo, error) {
+		t.Fatal("stat should not be called when OIDC_CLI_BIN is missing")
+		return nil, nil
+	})
+
+	if err == nil {
+		t.Fatal("expected missing OIDC_CLI_BIN to fail")
+	}
+	if got, want := err.Error(), "OIDC_CLI_BIN must point to the compiled oidc-cli binary"; got != want {
+		t.Fatalf("error message = %q, want %q", got, want)
+	}
+}
+
+func TestResolveBinaryRejectsInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	statErr := errors.New("no such file")
+	_, err := resolveBinary(func(string) string { return "/missing/oidc-cli" }, func(string) (os.FileInfo, error) {
+		return nil, statErr
+	})
+
+	if err == nil {
+		t.Fatal("expected invalid OIDC_CLI_BIN to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "OIDC_CLI_BIN must point to the compiled oidc-cli binary") || !strings.Contains(got, "no such file") {
+		t.Fatalf("error message = %q, want binary-path misconfiguration with stat error", got)
+	}
+}
+
+func TestResolveBinaryRejectsNonExecutableFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveBinary(func(string) string { return "/tmp/oidc-cli" }, func(string) (os.FileInfo, error) {
+		return fakeFileInfo{name: "oidc-cli", mode: 0o644}, nil
+	})
+
+	if err == nil {
+		t.Fatal("expected non-executable OIDC_CLI_BIN to fail")
+	}
+	if got, want := err.Error(), "OIDC_CLI_BIN must point to an executable oidc-cli binary, got \"/tmp/oidc-cli\""; got != want {
+		t.Fatalf("error message = %q, want %q", got, want)
+	}
+}
+
+func TestResolveBinaryAcceptsExecutableFile(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveBinary(func(string) string { return "/tmp/oidc-cli" }, func(string) (os.FileInfo, error) {
+		return fakeFileInfo{name: "oidc-cli", mode: 0o755}, nil
+	})
+	if err != nil {
+		t.Fatalf("resolveBinary returned error: %v", err)
+	}
+	if want := "/tmp/oidc-cli"; got != want {
+		t.Fatalf("binary path = %q, want %q", got, want)
+	}
+}
+
+func TestResultJSONParsesStdoutObject(t *testing.T) {
+	t.Parallel()
+
+	result := Result{Stdout: `{"access_token":"abc123","expires_in":3600,"token_type":"Bearer"}`}
+
+	parsed := result.JSON(t)
+
+	if got, want := parsed["access_token"], "abc123"; got != want {
+		t.Fatalf("access_token = %v, want %q", got, want)
+	}
+	if got, want := parsed["expires_in"], float64(3600); got != want {
+		t.Fatalf("expires_in = %v, want %v", got, want)
+	}
+	if got, want := parsed["token_type"], "Bearer"; got != want {
+		t.Fatalf("token_type = %v, want %q", got, want)
+	}
+}

--- a/test/acceptance/runner_acceptance.go
+++ b/test/acceptance/runner_acceptance.go
@@ -1,0 +1,70 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// RequireBinary returns the compiled oidc-cli binary path from OIDC_CLI_BIN.
+// Missing or invalid configuration is a harness failure, not a skipped test.
+func RequireBinary(tb testing.TB) string {
+	tb.Helper()
+
+	path, err := resolveBinary(os.Getenv, os.Stat)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return path
+}
+
+// Run executes the compiled oidc-cli binary with args and captures its exit
+// status, stdout, and stderr.
+func Run(tb testing.TB, args ...string) Result {
+	tb.Helper()
+	return RunWithContext(context.Background(), tb, args...)
+}
+
+// RunWithContext executes oidc-cli with args and captures its observable
+// process result.
+func RunWithContext(ctx context.Context, tb testing.TB, args ...string) Result {
+	tb.Helper()
+
+	bin := RequireBinary(tb)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...) // #nosec G204 -- acceptance tests intentionally execute the configured oidc-cli binary.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if errors.Is(ctxErr, context.DeadlineExceeded) {
+			tb.Fatalf("oidc-cli command timed out: %v", ctxErr)
+		}
+		tb.Fatalf("oidc-cli command cancelled: %v", ctxErr)
+	}
+
+	result := Result{
+		ExitCode: 0,
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			result.ExitCode = exitErr.ExitCode()
+			return result
+		}
+		tb.Fatalf("failed to run oidc-cli: %v", err)
+	}
+	return result
+}


### PR DESCRIPTION
Add a Go-based acceptance harness for running the compiled oidc-cli binary as a subprocess. The harness requires OIDC_CLI_BIN, fails loudly when the binary path is missing or invalid, captures exit status and output streams, and provides JSON stdout parsing for token-response commands.

Wire the suite into make acceptance, include it in the local ci target, and add a separate GitHub Actions acceptance job so the black-box CLI checks run as their own PR signal.