### PR TITLE
test: cover token refresh acceptance

### DIFF
--- a/test/acceptance/helpers_acceptance_test.go
+++ b/test/acceptance/helpers_acceptance_test.go
@@ -1,0 +1,151 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const (
+	expectedClientID     = "acceptance-client"
+	expectedClientSecret = "acceptance-secret"
+)
+
+type tokenRequest struct {
+	Method        string
+	Authorization string
+	GrantType     string
+	ClientID      string
+	ClientSecret  string
+	RefreshToken  string
+	Scope         string
+}
+
+type tokenEndpointBehavior struct {
+	valid       func(tokenRequest) bool
+	errorStatus int
+	errorBody   map[string]any
+	successBody func(tokenRequest) map[string]any
+}
+
+type tokenProvider struct {
+	server *httptest.Server
+
+	behavior tokenEndpointBehavior
+
+	mu                sync.Mutex
+	discoveryRequests int
+	tokenRequests     []tokenRequest
+}
+
+func newTokenProvider(t *testing.T, behavior tokenEndpointBehavior) *tokenProvider {
+	t.Helper()
+
+	provider := &tokenProvider{behavior: behavior}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/.well-known/openid-configuration", provider.handleDiscovery)
+	mux.HandleFunc("/token", provider.handleToken)
+
+	provider.server = httptest.NewServer(mux)
+	t.Cleanup(provider.server.Close)
+
+	return provider
+}
+
+func (p *tokenProvider) issuer() string {
+	return p.server.URL
+}
+
+func (p *tokenProvider) requests() (int, []tokenRequest) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	requests := make([]tokenRequest, len(p.tokenRequests))
+	copy(requests, p.tokenRequests)
+	return p.discoveryRequests, requests
+}
+
+func (p *tokenProvider) handleDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	p.mu.Lock()
+	p.discoveryRequests++
+	p.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                p.server.URL,
+		"token_endpoint":                        p.server.URL + "/token",
+		"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
+	})
+}
+
+func (p *tokenProvider) handleToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+
+	request := tokenRequest{
+		Method:        r.Method,
+		Authorization: r.Header.Get("Authorization"),
+		GrantType:     r.PostForm.Get("grant_type"),
+		ClientID:      r.PostForm.Get("client_id"),
+		ClientSecret:  r.PostForm.Get("client_secret"),
+		RefreshToken:  r.PostForm.Get("refresh_token"),
+		Scope:         r.PostForm.Get("scope"),
+	}
+
+	p.mu.Lock()
+	p.tokenRequests = append(p.tokenRequests, request)
+	p.mu.Unlock()
+
+	if !p.behavior.valid(request) {
+		writeJSON(w, p.behavior.errorStatus, p.behavior.errorBody)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, p.behavior.successBody(request))
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func assertEqual(t *testing.T, got, want any, name string) {
+	t.Helper()
+
+	if got != want {
+		t.Fatalf("%s: got %#v, want %#v", name, got, want)
+	}
+}
+
+func assertContains(t *testing.T, got, want, name string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf("%s: got %#v, want it to contain %#v", name, got, want)
+	}
+}
+
+func assertNotContains(t *testing.T, got, unwanted, name string) {
+	t.Helper()
+
+	if strings.Contains(got, unwanted) {
+		t.Fatalf("%s: got %#v, want it not to contain %#v", name, got, unwanted)
+	}
+}

--- a/test/acceptance/token_refresh_test.go
+++ b/test/acceptance/token_refresh_test.go
@@ -7,40 +7,45 @@ import (
 	"testing"
 )
 
-func newClientCredentialsProvider(t *testing.T) *tokenProvider {
+const expectedRefreshToken = "acceptance-refresh-token"
+
+func newTokenRefreshProvider(t *testing.T) *tokenProvider {
 	t.Helper()
 
 	return newTokenProvider(t, tokenEndpointBehavior{
 		valid: func(request tokenRequest) bool {
-			return request.GrantType == "client_credentials" &&
+			return request.GrantType == "refresh_token" &&
 				request.ClientID == expectedClientID &&
-				request.ClientSecret == expectedClientSecret
+				request.ClientSecret == expectedClientSecret &&
+				request.RefreshToken == expectedRefreshToken
 		},
-		errorStatus: http.StatusUnauthorized,
+		errorStatus: http.StatusBadRequest,
 		errorBody: map[string]any{
-			"error":             "invalid_client",
-			"error_description": "client credentials were not accepted",
+			"error":             "invalid_grant",
+			"error_description": "refresh token was not accepted",
 		},
 		successBody: func(request tokenRequest) map[string]any {
 			return map[string]any{
-				"access_token": "acceptance-access-token",
-				"token_type":   "Bearer",
-				"expires_in":   3600,
-				"scope":        request.Scope,
+				"access_token":  "refreshed-access-token",
+				"refresh_token": "rotated-refresh-token",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"scope":         request.Scope,
 			}
 		},
 	})
 }
 
-func TestClientCredentialsSuccess(t *testing.T) {
-	provider := newClientCredentialsProvider(t)
+func TestTokenRefreshSuccess(t *testing.T) {
+	provider := newTokenRefreshProvider(t)
 
 	result := Run(t,
-		"client_credentials",
+		"token_refresh",
 		"--issuer", provider.issuer(),
 		"--client-id", expectedClientID,
 		"--client-secret", expectedClientSecret,
 		"--auth-method", "client_secret_post",
+		"--refresh-token", expectedRefreshToken,
 		"--scope", "openid profile",
 	)
 
@@ -50,7 +55,8 @@ func TestClientCredentialsSuccess(t *testing.T) {
 
 	token := result.JSON(t)
 
-	assertEqual(t, token["access_token"], "acceptance-access-token", "access_token")
+	assertEqual(t, token["access_token"], "refreshed-access-token", "access_token")
+	assertEqual(t, token["refresh_token"], "rotated-refresh-token", "refresh_token")
 	assertEqual(t, token["token_type"], "Bearer", "token_type")
 	assertEqual(t, token["expires_in"], float64(3600), "expires_in")
 	assertEqual(t, token["scope"], "openid profile", "scope")
@@ -62,21 +68,24 @@ func TestClientCredentialsSuccess(t *testing.T) {
 	}
 	assertEqual(t, requests[0].Method, http.MethodPost, "token request method")
 	assertEqual(t, requests[0].Authorization, "", "authorization header")
-	assertEqual(t, requests[0].GrantType, "client_credentials", "grant_type")
+	assertEqual(t, requests[0].GrantType, "refresh_token", "grant_type")
 	assertEqual(t, requests[0].ClientID, expectedClientID, "client_id")
 	assertEqual(t, requests[0].ClientSecret, expectedClientSecret, "client_secret")
+	assertEqual(t, requests[0].RefreshToken, expectedRefreshToken, "refresh_token")
 	assertEqual(t, requests[0].Scope, "openid profile", "scope")
 }
 
-func TestClientCredentialsTokenError(t *testing.T) {
-	provider := newClientCredentialsProvider(t)
+func TestTokenRefreshTokenError(t *testing.T) {
+	provider := newTokenRefreshProvider(t)
+	wrongRefreshToken := "wrong-refresh-token"
 
 	result := Run(t,
-		"client_credentials",
+		"token_refresh",
 		"--issuer", provider.issuer(),
 		"--client-id", expectedClientID,
-		"--client-secret", "wrong-secret",
+		"--client-secret", expectedClientSecret,
 		"--auth-method", "client_secret_post",
+		"--refresh-token", wrongRefreshToken,
 	)
 
 	if result.ExitCode == 0 {
@@ -84,8 +93,9 @@ func TestClientCredentialsTokenError(t *testing.T) {
 	}
 	assertEqual(t, result.Stdout, "", "stdout")
 	assertContains(t, result.Stderr, "authorization server rejected token request", "stderr")
-	assertContains(t, result.Stderr, "invalid_client", "stderr")
-	assertNotContains(t, result.Stderr, "wrong-secret", "stderr")
+	assertContains(t, result.Stderr, "invalid_grant", "stderr")
+	assertNotContains(t, result.Stderr, expectedClientSecret, "stderr")
+	assertNotContains(t, result.Stderr, wrongRefreshToken, "stderr")
 
 	discoveryRequests, requests := provider.requests()
 	assertEqual(t, discoveryRequests, 1, "discovery request count")
@@ -93,7 +103,8 @@ func TestClientCredentialsTokenError(t *testing.T) {
 		t.Fatalf("expected 1 token request, got %d: %#v", len(requests), requests)
 	}
 	assertEqual(t, requests[0].Authorization, "", "authorization header")
-	assertEqual(t, requests[0].GrantType, "client_credentials", "grant_type")
+	assertEqual(t, requests[0].GrantType, "refresh_token", "grant_type")
 	assertEqual(t, requests[0].ClientID, expectedClientID, "client_id")
-	assertEqual(t, requests[0].ClientSecret, "wrong-secret", "client_secret")
+	assertEqual(t, requests[0].ClientSecret, expectedClientSecret, "client_secret")
+	assertEqual(t, requests[0].RefreshToken, wrongRefreshToken, "refresh_token")
 }


### PR DESCRIPTION
## Summary

- add CLI acceptance coverage for the token_refresh flow
- extract the shared token-provider harness for flow-level acceptance tests
- verify discovery, client_secret_post refresh-token requests, success JSON output, token endpoint errors, and secret non-leakage

## Tests

- make acceptance
- golangci-lint run
- make ci
