### PR TITLE
test: cover token endpoint failures

### DIFF
--- a/test/acceptance/helpers_acceptance_test.go
+++ b/test/acceptance/helpers_acceptance_test.go
@@ -27,10 +27,13 @@ type tokenRequest struct {
 }
 
 type tokenEndpointBehavior struct {
-	valid       func(tokenRequest) bool
-	errorStatus int
-	errorBody   map[string]any
-	successBody func(tokenRequest) map[string]any
+	valid func(tokenRequest) bool
+	// tokenResponse fully owns the token endpoint response when set; the
+	// valid/error/success fields are ignored.
+	tokenResponse func(http.ResponseWriter, tokenRequest)
+	errorStatus   int
+	errorBody     map[string]any
+	successBody   func(tokenRequest) map[string]any
 }
 
 type tokenProvider struct {
@@ -116,6 +119,11 @@ func (p *tokenProvider) handleToken(w http.ResponseWriter, r *http.Request) {
 	p.tokenRequests = append(p.tokenRequests, request)
 	p.mu.Unlock()
 
+	if p.behavior.tokenResponse != nil {
+		p.behavior.tokenResponse(w, request)
+		return
+	}
+
 	if !p.behavior.valid(request) {
 		writeJSON(w, p.behavior.errorStatus, p.behavior.errorBody)
 		return
@@ -128,6 +136,12 @@ func writeJSON(w http.ResponseWriter, status int, value any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeText(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
 }
 
 func assertEqual(t *testing.T, got, want any, name string) {

--- a/test/acceptance/token_endpoint_errors_test.go
+++ b/test/acceptance/token_endpoint_errors_test.go
@@ -1,0 +1,111 @@
+//go:build acceptance
+
+package acceptance
+
+import (
+	"net/http"
+	"testing"
+)
+
+const sensitiveErrorRefreshToken = "sensitive-error-refresh-token"
+
+func TestTokenEndpointFailureMessages(t *testing.T) {
+	tests := []struct {
+		name            string
+		response        func(http.ResponseWriter)
+		expectedStderr  []string
+		unexpectedLeaks []string
+	}{
+		{
+			name: "invalid JSON",
+			response: func(w http.ResponseWriter) {
+				writeText(w, http.StatusOK, "{not-json")
+			},
+			expectedStderr: []string{
+				"invalid JSON response in token",
+				"json parsing error",
+			},
+			unexpectedLeaks: []string{expectedClientSecret, sensitiveErrorRefreshToken},
+		},
+		{
+			name: "non-OAuth HTTP failure",
+			response: func(w http.ResponseWriter) {
+				writeJSON(w, http.StatusInternalServerError, map[string]any{
+					"message": "provider unavailable",
+				})
+			},
+			expectedStderr: []string{
+				"HTTP request failed in token",
+				"request failed with status: 500",
+				"provider unavailable",
+			},
+			unexpectedLeaks: []string{expectedClientSecret, sensitiveErrorRefreshToken},
+		},
+		{
+			name: "OAuth error with description",
+			response: func(w http.ResponseWriter) {
+				writeJSON(w, http.StatusBadRequest, map[string]any{
+					"error":             "invalid_grant",
+					"error_description": "refresh token expired",
+				})
+			},
+			expectedStderr: []string{
+				"authorization server rejected token request",
+				"invalid_grant",
+				"refresh token expired",
+			},
+			unexpectedLeaks: []string{expectedClientSecret, sensitiveErrorRefreshToken},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := newTokenEndpointErrorProvider(t, tt.response)
+
+			result := Run(t,
+				"token_refresh",
+				"--issuer", provider.issuer(),
+				"--client-id", expectedClientID,
+				"--client-secret", expectedClientSecret,
+				"--auth-method", "client_secret_post",
+				"--refresh-token", sensitiveErrorRefreshToken,
+				"--scope", "openid profile",
+			)
+
+			if result.ExitCode == 0 {
+				t.Fatalf("expected non-zero exit code\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+			}
+			assertEqual(t, result.Stdout, "", "stdout")
+			for _, want := range tt.expectedStderr {
+				assertContains(t, result.Stderr, want, "stderr")
+			}
+			for _, leak := range tt.unexpectedLeaks {
+				assertNotContains(t, result.Stdout, leak, "stdout")
+				assertNotContains(t, result.Stderr, leak, "stderr")
+			}
+
+			discoveryRequests, requests := provider.requests()
+			assertEqual(t, discoveryRequests, 1, "discovery request count")
+			if len(requests) != 1 {
+				t.Fatalf("expected 1 token request, got %d: %#v", len(requests), requests)
+			}
+			assertEqual(t, requests[0].Method, http.MethodPost, "token request method")
+			assertEqual(t, requests[0].Authorization, "", "authorization header")
+			assertEqual(t, requests[0].GrantType, "refresh_token", "grant_type")
+			assertEqual(t, requests[0].ClientID, expectedClientID, "client_id")
+			assertEqual(t, requests[0].ClientSecret, expectedClientSecret, "client_secret")
+			assertEqual(t, requests[0].RefreshToken, sensitiveErrorRefreshToken, "refresh_token")
+			assertEqual(t, requests[0].Scope, "openid profile", "scope")
+		})
+	}
+}
+
+func newTokenEndpointErrorProvider(t *testing.T, response func(http.ResponseWriter)) *tokenProvider {
+	t.Helper()
+
+	return newTokenProvider(t, tokenEndpointBehavior{
+		tokenResponse: func(w http.ResponseWriter, _ tokenRequest) {
+			response(w)
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Add CLI acceptance tests for token endpoint failure responses
- Cover invalid JSON, non-OAuth HTTP failures, and OAuth errors with descriptions
- Assert empty stdout, useful stderr, no submitted secret leaks, and the observed token request parameters

## Verification

- make ci