### PR TITLE
Add no-browser mode

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -34,6 +34,22 @@ If you often execute `oidc-cli` toward the same authorization server and using t
 alias oidc-cli="oidc-cli --issuer <issuer> --client-id <client id>
 ```
 
+### Run browser-based flows without launching a browser
+
+Use the global `--no-browser` flag before the command when running in a headless environment, over SSH, or when you want to open the authorization URL manually. The OAuth flow is unchanged; `oidc-cli` prints manual continuation instructions to stderr and keeps stdout reserved for the final JSON token response.
+
+Authorization code flow:
+
+```sh
+oidc-cli --no-browser authorization_code [--pkce]
+```
+
+Device flow:
+
+```sh
+oidc-cli --no-browser device
+```
+
 ## Authenticate and retrieve access token
 
 Run a regular authorization code flow (with or without PKCE)

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -14,6 +14,7 @@ func initGlobalConfig(args []string, logger *log.Logger) (oidcConf *oidc.Config,
 
 	var verbose bool
 	var skipTLSVerify bool
+	var noBrowser bool
 
 	flags = flag.NewFlagSet("global flags", flag.ContinueOnError)
 	var buf bytes.Buffer
@@ -25,6 +26,7 @@ func initGlobalConfig(args []string, logger *log.Logger) (oidcConf *oidc.Config,
 	flags.StringVar(&oidcConf.OIDC.ClientSecret, "client-secret", "", "set client secret")
 
 	flags.BoolVar(&skipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
+	flags.BoolVar(&noBrowser, "no-browser", false, "do not open a browser automatically")
 	flags.BoolVar(&verbose, "verbose", false, "enable verbose output")
 
 	err = flags.Parse(args)
@@ -36,6 +38,7 @@ func initGlobalConfig(args []string, logger *log.Logger) (oidcConf *oidc.Config,
 	oidcConf.Runtime.Logger = logger
 	oidcConf.Runtime.Client = httpclient.NewClient(&httpclient.Config{
 		SkipTLSVerify: skipTLSVerify,
+		NoBrowser:     noBrowser,
 		Logger:        logger,
 	})
 

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -120,6 +120,32 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 	}
 }
 
+func TestInitGlobalConfigWiresNoBrowser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"flag disables browser", []string{"--no-browser"}, true},
+		{"default leaves browser enabled", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			conf, _, err := initGlobalConfig(tt.args, log.Discard())
+			if err != nil {
+				t.Fatalf("initGlobalConfig: %v", err)
+			}
+			if got := conf.Runtime.Client.BrowserDisabled(); got != tt.want {
+				t.Errorf("BrowserDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestInitGlobalConfigWiresSkipTLSVerify pins that --skip-tls-verify is wired
 // from the command boundary through to the constructed client: with the flag,
 // the client reaches a self-signed server; without it, the same server is

--- a/httpclient/authorization_code.go
+++ b/httpclient/authorization_code.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/jentz/oidc-cli/log"
 	"github.com/jentz/oidc-cli/webflow"
 )
 
@@ -122,8 +123,11 @@ func (c *Client) ExecuteAuthorizationCodeRequest(ctx context.Context, endpoint, 
 	}
 	c.logger.Printf("authorization request: %s\n", requestURL)
 
-	if err := c.OpenURL(requestURL); err != nil {
-		c.logger.Errorf("unable to open browser because %v, visit %s to continue\n", err, requestURL)
+	if c.BrowserDisabled() {
+		printAuthorizationContinuationInstructions(c.logger, requestURL)
+	} else if err := c.OpenURL(requestURL); err != nil {
+		c.logger.Errorf("Unable to open browser automatically: %v\n", err)
+		printAuthorizationContinuationInstructions(c.logger, requestURL)
 	}
 
 	callbackResp, err := server.WaitForCallback(ctx)
@@ -132,6 +136,10 @@ func (c *Client) ExecuteAuthorizationCodeRequest(ctx context.Context, endpoint, 
 	}
 
 	return validateCallbackResponse(req, callbackResp)
+}
+
+func printAuthorizationContinuationInstructions(logger *log.Logger, requestURL string) {
+	logger.Errorf("Open this URL in a browser to authorize:\n%s\n", requestURL)
 }
 
 // startCallbackServer starts the callback server in the background, returning

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -25,6 +25,8 @@ type Config struct {
 	Logger        *log.Logger       // Logger for client output; if nil, output is discarded
 	// Browser opens authorization URLs; nil falls back to webflow.NewBrowser().
 	Browser webflow.Browser
+	// NoBrowser suppresses automatic browser launch for interactive flows.
+	NoBrowser bool
 	// Listen creates the callback server's listener; nil falls back to net.Listen.
 	Listen func(network, addr string) (net.Listener, error)
 }
@@ -36,6 +38,7 @@ type SleepFunc func(ctx context.Context, d time.Duration) error
 type Client struct {
 	client    *http.Client
 	browser   webflow.Browser
+	noBrowser bool
 	listen    func(network, addr string) (net.Listener, error)
 	sleepFunc SleepFunc // nil falls back to sleepWithContext
 	logger    *log.Logger
@@ -96,15 +99,21 @@ func NewClient(cfg *Config) *Client {
 			Transport: transport,
 			Timeout:   cfg.Timeout,
 		},
-		browser: browser,
-		listen:  listen,
-		logger:  logger,
+		browser:   browser,
+		noBrowser: cfg.NoBrowser,
+		listen:    listen,
+		logger:    logger,
 	}
 }
 
 // OpenURL opens url in the client's browser.
 func (c *Client) OpenURL(rawURL string) error {
 	return c.browser.Open(rawURL)
+}
+
+// BrowserDisabled reports whether automatic browser launch is suppressed.
+func (c *Client) BrowserDisabled() bool {
+	return c.noBrowser
 }
 
 // SetSleepFunc sets a custom sleep function, primarily for testing.

--- a/oidc/authorization_code_test.go
+++ b/oidc/authorization_code_test.go
@@ -43,7 +43,7 @@ func (b *callbackFiringBrowser) Open(rawURL string) error {
 func fireCallbackAsync(callbackTarget string) <-chan error {
 	callbackErr := make(chan error, 1)
 	go func() {
-		for attempt := 0; attempt < 20; attempt++ {
+		for attempt := 0; attempt < 120; attempt++ {
 			resp, err := http.Get(callbackTarget) //nolint:noctx // test-local loopback request
 			if err == nil {
 				callbackErr <- resp.Body.Close()
@@ -240,10 +240,6 @@ func TestAuthorizationCodeFlowRun(t *testing.T) {
 	}
 }
 
-// TestAuthorizationCodeFlowRunPublicClient pins the PKCE no-secret fallback:
-// with no client secret, the flow's PKCE setup must switch to no client
-// authentication, so the token request carries client_id in the body and no
-// Authorization header (and never an empty-secret Basic header).
 func TestAuthorizationCodeFlowRunNoBrowserPrintsAuthorizationURL(t *testing.T) {
 	t.Parallel()
 
@@ -268,7 +264,7 @@ func TestAuthorizationCodeFlowRunNoBrowserPrintsAuthorizationURL(t *testing.T) {
 		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	callbackErr := fireCallbackAsync(callbackTarget)
@@ -333,7 +329,7 @@ func TestAuthorizationCodeFlowRunBrowserFailurePrintsRecoveryInstructions(t *tes
 		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	callbackErr := fireCallbackAsync(callbackTarget)
 
@@ -364,6 +360,10 @@ func TestAuthorizationCodeFlowRunBrowserFailurePrintsRecoveryInstructions(t *tes
 	}
 }
 
+// TestAuthorizationCodeFlowRunPublicClient pins the PKCE no-secret fallback:
+// with no client secret, the flow's PKCE setup must switch to no client
+// authentication, so the token request carries client_id in the body and no
+// Authorization header (and never an empty-secret Basic header).
 func TestAuthorizationCodeFlowRunPublicClient(t *testing.T) {
 	t.Parallel()
 

--- a/oidc/authorization_code_test.go
+++ b/oidc/authorization_code_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jentz/oidc-cli/crypto/cryptotest"
 )
@@ -37,6 +38,22 @@ func (b *callbackFiringBrowser) Open(rawURL string) error {
 		return b.fire()
 	}
 	return nil
+}
+
+func fireCallbackAsync(callbackTarget string) <-chan error {
+	callbackErr := make(chan error, 1)
+	go func() {
+		for attempt := 0; attempt < 20; attempt++ {
+			resp, err := http.Get(callbackTarget) //nolint:noctx // test-local loopback request
+			if err == nil {
+				callbackErr <- resp.Body.Close()
+				return
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+		callbackErr <- fmt.Errorf("callback endpoint did not accept request at %s", callbackTarget)
+	}()
+	return callbackErr
 }
 
 func TestAuthorizationCodeFlowRun(t *testing.T) {
@@ -227,6 +244,126 @@ func TestAuthorizationCodeFlowRun(t *testing.T) {
 // with no client secret, the flow's PKCE setup must switch to no client
 // authentication, so the token request carries client_id in the body and no
 // Authorization header (and never an empty-secret Basic header).
+func TestAuthorizationCodeFlowRunNoBrowserPrintsAuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	const (
+		callbackURI = "http://localhost/callback"
+		authCode    = "manual-auth-code"
+		state       = "manual-state"
+	)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("binding loopback listener: %v", err)
+	}
+	callbackTarget := fmt.Sprintf("http://%s/callback?code=%s&state=%s",
+		ln.Addr().String(), url.QueryEscape(authCode), url.QueryEscape(state))
+
+	browser := &recordingBrowser{}
+	fixture := newReadyConfig(t,
+		withNoBrowser(),
+		withBrowser(browser),
+		withListener(func(_, _ string) (net.Listener, error) { return ln, nil }),
+		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	callbackErr := fireCallbackAsync(callbackTarget)
+
+	flow := &AuthorizationCodeFlow{
+		Config: fixture.config,
+		FlowConfig: &AuthorizationCodeFlowConfig{
+			CallbackURI: callbackURI,
+			State:       state,
+		},
+	}
+	if err := flow.Run(ctx); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if err := <-callbackErr; err != nil {
+		t.Fatalf("firing callback: %v", err)
+	}
+
+	if browser.openedURL != "" {
+		t.Errorf("opened URL = %q, want no browser launch", browser.openedURL)
+	}
+	wantAuthorizationURL := "https://op.example.com/authorize?client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&response_type=code&state=manual-state"
+	wantErr := "Open this URL in a browser to authorize:\n" + wantAuthorizationURL + "\n"
+	if got := fixture.errOutput.String(); got != wantErr {
+		t.Errorf("stderr = %q, want %q", got, wantErr)
+	}
+
+	tokenReq := fixture.onlyRequest(t)
+	if got := tokenReq.Form.Get("code"); got != authCode {
+		t.Errorf("token code = %q, want %q", got, authCode)
+	}
+	wantOutput := `{
+  "access_token": "abc123",
+  "token_type": "Bearer"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("stdout = %q, want final JSON only", got)
+	}
+}
+
+func TestAuthorizationCodeFlowRunBrowserFailurePrintsRecoveryInstructions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		callbackURI = "http://localhost/callback"
+		authCode    = "recovery-auth-code"
+		state       = "recovery-state"
+	)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("binding loopback listener: %v", err)
+	}
+	callbackTarget := fmt.Sprintf("http://%s/callback?code=%s&state=%s",
+		ln.Addr().String(), url.QueryEscape(authCode), url.QueryEscape(state))
+
+	browser := &failingBrowser{}
+	fixture := newReadyConfig(t,
+		withBrowser(browser),
+		withListener(func(_, _ string) (net.Listener, error) { return ln, nil }),
+		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	callbackErr := fireCallbackAsync(callbackTarget)
+
+	flow := &AuthorizationCodeFlow{
+		Config: fixture.config,
+		FlowConfig: &AuthorizationCodeFlowConfig{
+			CallbackURI: callbackURI,
+			State:       state,
+		},
+	}
+	if err := flow.Run(ctx); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if err := <-callbackErr; err != nil {
+		t.Fatalf("firing callback: %v", err)
+	}
+
+	wantAuthorizationURL := "https://op.example.com/authorize?client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%2Fcallback&response_type=code&state=recovery-state"
+	if browser.openedURL != wantAuthorizationURL {
+		t.Errorf("opened URL = %q, want %q", browser.openedURL, wantAuthorizationURL)
+	}
+	wantErr := "Unable to open browser automatically: browser command missing\nOpen this URL in a browser to authorize:\n" + wantAuthorizationURL + "\n"
+	if got := fixture.errOutput.String(); got != wantErr {
+		t.Errorf("stderr = %q, want %q", got, wantErr)
+	}
+	if got := fixture.onlyRequest(t).Form.Get("code"); got != authCode {
+		t.Errorf("token code = %q, want %q", got, authCode)
+	}
+}
+
 func TestAuthorizationCodeFlowRunPublicClient(t *testing.T) {
 	t.Parallel()
 

--- a/oidc/device.go
+++ b/oidc/device.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jentz/oidc-cli/crypto"
 	"github.com/jentz/oidc-cli/httpclient"
+	"github.com/jentz/oidc-cli/log"
 )
 
 type DeviceFlow struct {
@@ -47,18 +48,22 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 	}
 
 	logger := c.Config.Runtime.Logger
-	if deviceAuthResp.VerificationURIComplete != "" {
-		verificationURI := deviceAuthResp.VerificationURIComplete
+	verificationURI := deviceAuthResp.VerificationURIComplete
+	userCode := ""
+	if verificationURI == "" {
+		verificationURI = deviceAuthResp.VerificationURI
+		userCode = deviceAuthResp.UserCode
+	}
+	if userCode == "" {
 		logger.Printf("device verification uri: %s\n", verificationURI)
-		if err := client.OpenURL(verificationURI); err != nil {
-			logger.Errorf("failed to open verification uri %s in the browser: %v\n", verificationURI, err)
-		}
 	} else {
-		verificationURI := deviceAuthResp.VerificationURI
-		logger.Printf("device verification uri: %s, verification code: %s\n", verificationURI, deviceAuthResp.UserCode)
-		if err := client.OpenURL(verificationURI); err != nil {
-			logger.Errorf("failed to open verification uri %s in the browser: %v\n", verificationURI, err)
-		}
+		logger.Printf("device verification uri: %s, verification code: %s\n", verificationURI, userCode)
+	}
+	if client.BrowserDisabled() {
+		printDeviceContinuationInstructions(logger, verificationURI, userCode)
+	} else if err := client.OpenURL(verificationURI); err != nil {
+		logger.Errorf("Unable to open browser automatically: %v\n", err)
+		printDeviceContinuationInstructions(logger, verificationURI, userCode)
 	}
 
 	// Poll for token
@@ -84,4 +89,11 @@ func (c *DeviceFlow) Run(ctx context.Context) error {
 	}
 
 	return logger.OutputJSON(tokenData)
+}
+
+func printDeviceContinuationInstructions(logger *log.Logger, verificationURI, userCode string) {
+	logger.Errorf("Open this URL in a browser to authorize the device:\n%s\n", verificationURI)
+	if userCode != "" {
+		logger.Errorf("\nEnter this code:\n%s\n", userCode)
+	}
 }

--- a/oidc/device_test.go
+++ b/oidc/device_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -23,6 +24,15 @@ type recordingBrowser struct {
 func (b *recordingBrowser) Open(rawURL string) error {
 	b.openedURL = rawURL
 	return nil
+}
+
+type failingBrowser struct {
+	openedURL string
+}
+
+func (b *failingBrowser) Open(rawURL string) error {
+	b.openedURL = rawURL
+	return errors.New("browser command missing")
 }
 
 func TestDeviceFlowRun(t *testing.T) {
@@ -100,6 +110,67 @@ func TestDeviceFlowRun(t *testing.T) {
 `
 	if got := fixture.output.String(); got != wantOutput {
 		t.Errorf("output = %q, want %q", got, wantOutput)
+	}
+}
+
+func TestDeviceFlowRunNoBrowserPrintsManualInstructions(t *testing.T) {
+	t.Parallel()
+
+	deviceAuthBody := `{"device_code":"dev-code-1","user_code":"WDJB-MJHT","verification_uri":"https://op.example.com/device","interval":5,"expires_in":1800}`
+
+	browser := &recordingBrowser{}
+	fixture := newReadyConfig(t,
+		withNoBrowser(),
+		withBrowser(browser),
+		withRoute(testDeviceAuthEndpoint, http.StatusOK, deviceAuthBody),
+		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
+	)
+
+	flow := &DeviceFlow{Config: fixture.config, FlowConfig: &DeviceFlowConfig{Scope: "openid"}}
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if browser.openedURL != "" {
+		t.Errorf("opened URL = %q, want no browser launch", browser.openedURL)
+	}
+	wantErr := "Open this URL in a browser to authorize the device:\nhttps://op.example.com/device\n\nEnter this code:\nWDJB-MJHT\n"
+	if got := fixture.errOutput.String(); got != wantErr {
+		t.Errorf("stderr = %q, want %q", got, wantErr)
+	}
+	wantOutput := `{
+  "access_token": "abc123",
+  "token_type": "Bearer"
+}
+`
+	if got := fixture.output.String(); got != wantOutput {
+		t.Errorf("stdout = %q, want final JSON only", got)
+	}
+}
+
+func TestDeviceFlowRunBrowserFailurePrintsRecoveryInstructions(t *testing.T) {
+	t.Parallel()
+
+	deviceAuthBody := `{"device_code":"dev-code-1","user_code":"WDJB-MJHT","verification_uri":"https://op.example.com/device","verification_uri_complete":"https://op.example.com/device?user_code=WDJB-MJHT","interval":5,"expires_in":1800}`
+
+	browser := &failingBrowser{}
+	fixture := newReadyConfig(t,
+		withBrowser(browser),
+		withRoute(testDeviceAuthEndpoint, http.StatusOK, deviceAuthBody),
+		withResponse(http.StatusOK, `{"access_token":"abc123","token_type":"Bearer"}`),
+	)
+
+	flow := &DeviceFlow{Config: fixture.config, FlowConfig: &DeviceFlowConfig{Scope: "openid"}}
+	if err := flow.Run(context.Background()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if browser.openedURL != "https://op.example.com/device?user_code=WDJB-MJHT" {
+		t.Errorf("opened URL = %q, want verification_uri_complete", browser.openedURL)
+	}
+	wantErr := "Unable to open browser automatically: browser command missing\nOpen this URL in a browser to authorize the device:\nhttps://op.example.com/device?user_code=WDJB-MJHT\n"
+	if got := fixture.errOutput.String(); got != wantErr {
+		t.Errorf("stderr = %q, want %q", got, wantErr)
 	}
 }
 

--- a/oidc/flow_harness_test.go
+++ b/oidc/flow_harness_test.go
@@ -48,9 +48,10 @@ type capturedRequest struct {
 // calling goroutine; the interactive callback round-trip rides a real loopback
 // listener that never touches this transport, so no append races it.
 type flowFixture struct {
-	config   *Config
-	requests []*capturedRequest
-	output   *bytes.Buffer
+	config    *Config
+	requests  []*capturedRequest
+	output    *bytes.Buffer
+	errOutput *bytes.Buffer
 
 	// dpopPublicKey is the key the fixture's DPoP proofs are bound to, set only
 	// when withDPoPKeys is used, so tests can verify the emitted proof.
@@ -73,9 +74,10 @@ type fixtureSettings struct {
 	// routes overrides the default response per request URL, letting an
 	// interactive flow return a request_uri from the PAR endpoint and a token
 	// from the token endpoint within one Run.
-	routes  map[string]cannedResponse
-	browser webflow.Browser
-	listen  func(network, addr string) (net.Listener, error)
+	routes    map[string]cannedResponse
+	browser   webflow.Browser
+	noBrowser bool
+	listen    func(network, addr string) (net.Listener, error)
 }
 
 type fixtureOption func(*fixtureSettings)
@@ -101,6 +103,11 @@ func withBrowser(b webflow.Browser) fixtureOption {
 // with, letting a test drive the redirect over a pre-bound loopback port.
 func withListener(fn func(network, addr string) (net.Listener, error)) fixtureOption {
 	return func(s *fixtureSettings) { s.listen = fn }
+}
+
+// withNoBrowser suppresses automatic browser launch on the runtime client.
+func withNoBrowser() fixtureOption {
+	return func(s *fixtureSettings) { s.noBrowser = true }
 }
 
 // withAuthMethod overrides the client authentication method (default Basic).
@@ -151,7 +158,7 @@ func newReadyConfig(t *testing.T, opts ...fixtureOption) *flowFixture {
 		opt(settings)
 	}
 
-	fixture := &flowFixture{output: &bytes.Buffer{}}
+	fixture := &flowFixture{output: &bytes.Buffer{}, errOutput: &bytes.Buffer{}}
 
 	transport := mockTransport(func(req *http.Request) (*http.Response, error) {
 		fixture.requests = append(fixture.requests, captureRequest(t, req))
@@ -166,13 +173,13 @@ func newReadyConfig(t *testing.T, opts ...fixtureOption) *flowFixture {
 		}, nil
 	})
 
-	logger := log.New(log.WithOutput(fixture.output, io.Discard))
-	// The client keeps its own (discard) logger so the output buffer captures
-	// the flow's output alone, independent of any client-side logging.
+	logger := log.New(log.WithOutput(fixture.output, fixture.errOutput))
 	client := httpclient.NewClient(&httpclient.Config{
 		Transport: transport,
 		Browser:   settings.browser,
+		NoBrowser: settings.noBrowser,
 		Listen:    settings.listen,
+		Logger:    logger,
 	})
 
 	fixture.config = &Config{


### PR DESCRIPTION
## Summary
- Add a global --no-browser flag that suppresses automatic browser launch
- Print manual continuation instructions to stderr for device and authorization-code flows
- Print the same recovery instructions when browser launch fails

## Tests
- make ci